### PR TITLE
Made Context class a singleton

### DIFF
--- a/src/common/context.cc
+++ b/src/common/context.cc
@@ -3,7 +3,33 @@
 
 using namespace std;
 
+Context& context = *Context::connect();
+
+Context* Context::singleton = nullptr;
+
 // Constructors {{{
+Context* Context::connect (string title) {
+
+  if (singleton == nullptr) {
+    singleton = new Context(title);
+    singleton->init();
+    singleton->run();
+  }
+
+  return singleton;
+}
+
+Context* Context::connect () {
+
+  if (singleton == nullptr) {
+    singleton = new Context();
+    singleton->init();
+    singleton->run();
+  }
+
+  return singleton;
+}
+
 Context::Context(string s): settings(s), work(io) {
   init();
 }

--- a/src/common/context.hh
+++ b/src/common/context.hh
@@ -7,22 +7,29 @@
 #include <vector>
 #include <thread>
 
-struct Context {
-  boost::asio::io_service io;
-  std::unique_ptr<Logger, decltype(&Logger::disconnect)>
-    logger {nullptr, Logger::disconnect};
-  Settings settings;
-  int id;
+class Context {
+  public:
+    boost::asio::io_service io;
+    std::unique_ptr<Logger, decltype(&Logger::disconnect)>
+      logger {nullptr, Logger::disconnect};
+    Settings settings;
+    int id;
 
-  void run ();
-  bool join ();
+    void run ();
+    bool join ();
 
-  Context(std::string);
-  Context();
-  ~Context();
+    static Context* singleton;
+    static Context* connect(std::string);
+    static Context* connect();
 
   protected:
+    Context(std::string);
+    Context();
+    ~Context();
+
     void init();
     std::vector<std::unique_ptr<std::thread>> threads;
     boost::asio::io_service::work work;
 };
+
+extern Context& context;

--- a/src/fs/dfs.cc
+++ b/src/fs/dfs.cc
@@ -4,13 +4,12 @@ using namespace eclipse;
 
 namespace eclipse{
   void DFS::load_settings () {
-    Context con;
-    BLOCK_SIZE = con.settings.get<int>("filesystem.block");
-    NUM_SERVERS = con.settings.get<vector<string>>("network.nodes").size();
-    path = con.settings.get<string>("path.scratch");
-    replica = con.settings.get<int>("filesystem.replica");
-    port = con.settings.get<int> ("network.port_mapreduce");
-    nodes = con.settings.get<vector<string>>("network.nodes");
+    BLOCK_SIZE = context.settings.get<int>("filesystem.block");
+    NUM_SERVERS = context.settings.get<vector<string>>("network.nodes").size();
+    path = context.settings.get<string>("path.scratch");
+    replica = context.settings.get<int>("filesystem.replica");
+    port = context.settings.get<int> ("network.port_mapreduce");
+    nodes = context.settings.get<vector<string>>("network.nodes");
   }
 
   unique_ptr<tcp::socket> DFS::connect (uint32_t hash_value) { 
@@ -52,7 +51,6 @@ namespace eclipse{
 
   int DFS::put(int argc, char* argv[])
   {
-    Context con;
     if(argc < 3)
     {
       cout << "[INFO] dfs put file_1 file_2 ..." << endl;

--- a/src/fs/directory.cc
+++ b/src/fs/directory.cc
@@ -4,8 +4,7 @@ using namespace std;
 namespace eclipse{
   Directory::Directory()
   {
-    Context con;
-    path = con.settings.get<string>("path.metadata") + "/metadata.db";
+    path = context.settings.get<string>("path.metadata") + "/metadata.db";
     zErrMsg = 0;
   }
 
@@ -15,16 +14,15 @@ namespace eclipse{
 
   void Directory::open_db()
   {
-    Context con;
     // Open database
     rc = sqlite3_open(path.c_str(), &db);
     if(rc)
     {
-      con.logger->error("Can't open database: %s\n", sqlite3_errmsg(db));
+      context.logger->error("Can't open database: %s\n", sqlite3_errmsg(db));
     }
     else
     {
-      con.logger->info("Opened database successfully\n");
+      context.logger->info("Opened database successfully\n");
     }
   }
 
@@ -61,9 +59,8 @@ namespace eclipse{
 
   int Directory::display_callback(void *NotUsed, int argc, char **argv, char **azColName)
   {
-    Context con;
     for(int i=0; i<argc; i++)
-      con.logger->info("%s = %s\n", azColName[i], argv[i] ? argv[i] : "NULL");
+      context.logger->info("%s = %s\n", azColName[i], argv[i] ? argv[i] : "NULL");
     printf("\n");
     return 0;
   }
@@ -115,7 +112,6 @@ namespace eclipse{
 
   void Directory::init_db()
   {
-    Context con;
     // Open database
     open_db();
 
@@ -132,12 +128,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_table created successfully\n");
+      context.logger->info("file_table created successfully\n");
     }
 
     // Create SQL statement
@@ -158,12 +154,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_table created successfully\n");
+      context.logger->info("block_table created successfully\n");
     }
     // Close Database
     sqlite3_close(db);
@@ -171,7 +167,6 @@ namespace eclipse{
 
   void Directory::insert_file_metadata(FileInfo file_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -190,12 +185,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_metadata inserted successfully\n");
+      context.logger->info("file_metadata inserted successfully\n");
     }
 
     // Close Database
@@ -204,7 +199,6 @@ namespace eclipse{
 
   void Directory::insert_block_metadata(BlockInfo block_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -229,12 +223,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_metadata inserted successfully\n");
+      context.logger->info("block_metadata inserted successfully\n");
     }
 
     // Close Database
@@ -243,7 +237,6 @@ namespace eclipse{
 
   void Directory::select_file_metadata(string file_name, FileInfo *file_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -254,12 +247,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, file_callback, (void*)file_info, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_metadata selected successfully\n");
+      context.logger->info("file_metadata selected successfully\n");
     }
 
     // Close Database
@@ -268,7 +261,6 @@ namespace eclipse{
 
   void Directory::select_block_metadata(string file_name, unsigned int block_seq, BlockInfo *block_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -280,12 +272,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, block_callback, (void*)block_info, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_metadata selected successfully\n");
+      context.logger->info("block_metadata selected successfully\n");
     }
 
     // Close Database
@@ -294,7 +286,6 @@ namespace eclipse{
 
   void Directory::select_all_file_metadata(vector<FileInfo> &file_list)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -305,12 +296,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, file_list_callback, (void*)&file_list, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_metadata selected successfully\n");
+      context.logger->info("file_metadata selected successfully\n");
     }
 
     // Close Database
@@ -319,7 +310,6 @@ namespace eclipse{
 
   void Directory::select_all_block_metadata(vector<BlockInfo> &block_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -330,12 +320,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, block_list_callback, (void*)&block_info, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_metadata selected successfully\n");
+      context.logger->info("block_metadata selected successfully\n");
     }
 
     // Close Database
@@ -344,7 +334,6 @@ namespace eclipse{
 
   void Directory::update_file_metadata(string file_name, FileInfo file_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -364,12 +353,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_metadata updated successfully\n");
+      context.logger->info("file_metadata updated successfully\n");
     }
 
     // Close Database
@@ -378,7 +367,6 @@ namespace eclipse{
 
   void Directory::update_block_metadata(string file_name, unsigned int block_seq, BlockInfo block_info)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -404,12 +392,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_metadata updated successfully\n");
+      context.logger->info("block_metadata updated successfully\n");
     }
 
     // Close Database
@@ -418,7 +406,6 @@ namespace eclipse{
 
   void Directory::delete_file_metadata(string file_name)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -429,12 +416,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_metadata deleted successfully\n");
+      context.logger->info("file_metadata deleted successfully\n");
     }
 
     // Close Database
@@ -443,7 +430,6 @@ namespace eclipse{
 
   void Directory::delete_block_metadata(string file_name, unsigned int block_seq)
   {
-    Context con;
     // Open database
     open_db();
 
@@ -454,12 +440,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_metadata deleted successfully\n");
+      context.logger->info("block_metadata deleted successfully\n");
     }
 
     // Close Database
@@ -468,7 +454,6 @@ namespace eclipse{
 
   void Directory::display_file_metadata()
   {
-    Context con;
     // Open database
     open_db();
 
@@ -479,12 +464,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, display_callback, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_metadata displayed successfully\n");
+      context.logger->info("file_metadata displayed successfully\n");
     }
 
     // Close Database
@@ -493,7 +478,6 @@ namespace eclipse{
 
   void Directory::display_block_metadata()
   {
-    Context con;
     // Open database
     open_db();
 
@@ -504,12 +488,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, display_callback, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("block_metadata displayed successfully\n");
+      context.logger->info("block_metadata displayed successfully\n");
     }
 
     // Close Database
@@ -518,7 +502,6 @@ namespace eclipse{
 
   bool Directory::file_exist(string file_name)
   {
-    Context con;
     bool result = false;
 
     // Open database
@@ -531,12 +514,12 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, exist_callback, &result, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      con.logger->error("SQL error: %s\n", zErrMsg);
+      context.logger->error("SQL error: %s\n", zErrMsg);
       sqlite3_free(zErrMsg);
     }
     else
     {
-      con.logger->info("file_exist executed successfully\n");
+      context.logger->info("file_exist executed successfully\n");
     }
 
     // Close Database

--- a/src/network/acceptor.cc
+++ b/src/network/acceptor.cc
@@ -3,10 +3,10 @@
 using namespace eclipse::network;
 
 // Constructor {{{
-Acceptor::Acceptor(Context& c, int port_, NetObserver* o):
+Acceptor::Acceptor(int port_, NetObserver* o):
   observer(o),
-  iosvc (c.io),
-  nodes (c.settings.get<vec_str>("network.nodes")),
+  iosvc (context.io),
+  nodes (context.settings.get<vec_str>("network.nodes")),
   port  (port_)
 { }
 // }}}

--- a/src/network/acceptor.hh
+++ b/src/network/acceptor.hh
@@ -16,7 +16,7 @@ using vec_str = std::vector<std::string>;
 
 class Acceptor {
   public:
-    Acceptor(Context&, int, NetObserver*);
+    Acceptor(int, NetObserver*);
     void listen();
 
   protected:

--- a/src/network/asyncchannel.cc
+++ b/src/network/asyncchannel.cc
@@ -14,9 +14,7 @@ using namespace eclipse::messages;
 using namespace boost::system;
 
 // constructor {{{
-AsyncChannel::AsyncChannel(tcp::socket* s, tcp::socket* r,
-    Context& c, AsyncNode* node_) : 
-  Channel(c),
+AsyncChannel::AsyncChannel(tcp::socket* s, tcp::socket* r, AsyncNode* node_) : 
   node (node_),
   sender(s),
   receiver(r)
@@ -68,7 +66,6 @@ void AsyncChannel::read_coroutine (yield_context yield) {
 
       size_t size = atoi(header);
       l = async_read (*receiver, body.prepare(size), yield[ec]);
-      logger->info ("AsyncChannel: l=%d", l);
       if (ec) throw 1;
 
       body.commit (l);

--- a/src/network/asyncchannel.hh
+++ b/src/network/asyncchannel.hh
@@ -11,7 +11,7 @@ namespace network {
 
 class AsyncChannel: public Channel {
   public:
-    AsyncChannel(tcp::socket*, tcp::socket*, Context&, AsyncNode*);
+    AsyncChannel(tcp::socket*, tcp::socket*, AsyncNode*);
     void do_write (messages::Message*) override; 
     void do_read ();
 

--- a/src/network/asyncnetwork.hh
+++ b/src/network/asyncnetwork.hh
@@ -16,7 +16,7 @@ using boost::asio::ip::tcp;
 template<typename TYPE>
 class AsyncNetwork: public Network, public NetObserver {
   public:
-    AsyncNetwork(AsyncNode*, Context&, int);
+    AsyncNetwork(AsyncNode*, int);
     ~AsyncNetwork ();
 
     bool establish() override;
@@ -32,7 +32,6 @@ class AsyncNetwork: public Network, public NetObserver {
     void start_reading();
     bool is_completed_network();
 
-    Context& context;
     AsyncNode* node;
     vec_str nodes;
 
@@ -45,12 +44,11 @@ class AsyncNetwork: public Network, public NetObserver {
 };
 // Constructor {{{
 template<typename TYPE>
-AsyncNetwork<TYPE>::AsyncNetwork (AsyncNode* n, Context& c, int port):
-  context(c),
+AsyncNetwork<TYPE>::AsyncNetwork (AsyncNode* n, int port):
   node(n),
-  nodes(c.settings.get<vec_str> ("network.nodes")),
-  acceptor(c, port, this),
-  connector(c, port, this)
+  nodes(context.settings.get<vec_str> ("network.nodes")),
+  acceptor(port, this),
+  connector(port, this)
 { 
  if (TYPE::is_multiple())
    net_size = nodes.size() - 1;
@@ -159,7 +157,7 @@ void AsyncNetwork<TYPE>::start_reading () {
       if (channels.find(sp.first) != channels.end())
         channels.erase(sp.first);
 
-      channels.emplace (sp.first, std::make_unique<TYPE> (sp.second.first, sp.second.second, context, node));
+      channels.emplace (sp.first, std::make_unique<TYPE> (sp.second.first, sp.second.second, node));
     }
     sockets.clear();
     for (auto& channel : channels)

--- a/src/network/channel.cc
+++ b/src/network/channel.cc
@@ -2,8 +2,8 @@
 
 using namespace eclipse::network;
 
-Channel::Channel (Context& c) :
-  iosvc  (c.io), 
-  port   (c.settings.get<int>("network.port_cache")),
-  logger (c.logger.get()) 
+Channel::Channel () :
+  iosvc  (context.io), 
+  port   (context.settings.get<int>("network.port_cache")),
+  logger (context.logger.get()) 
 {}

--- a/src/network/channel.hh
+++ b/src/network/channel.hh
@@ -13,7 +13,7 @@ const int header_size = 16;
 
 class Channel {
   public:
-    Channel (Context&);
+    Channel ();
     ~Channel () = default;
 
     virtual void do_write (messages::Message*) = 0; 

--- a/src/network/connector.cc
+++ b/src/network/connector.cc
@@ -5,11 +5,11 @@ using namespace std;
 using namespace eclipse::network;
 namespace ph = boost::asio::placeholders;
 
-Connector::Connector(Context& c, int p, NetObserver* o) : 
-  nodes (c.settings.get<vec_str>("network.nodes")),
-  ip_of_this(c.settings.getip()),
+Connector::Connector(int p, NetObserver* o) : 
+  nodes (context.settings.get<vec_str>("network.nodes")),
+  ip_of_this(context.settings.getip()),
   observer(o), 
-  iosvc(c.io),
+  iosvc(context.io),
   port(p) {}
 
 // establish {{{

--- a/src/network/connector.hh
+++ b/src/network/connector.hh
@@ -14,7 +14,7 @@ using vec_str = std::vector<std::string>;
 
 class Connector {
   public:
-    Connector(Context&, int, NetObserver*); 
+    Connector(int, NetObserver*); 
     ~Connector() = default; 
 
     void establish ();

--- a/src/network/p2p.cc
+++ b/src/network/p2p.cc
@@ -3,8 +3,8 @@
 using namespace eclipse::network;
 
 // constructor {{{
-P2P::P2P(tcp::socket* a, tcp::socket* b, Context& c, AsyncNode* node_) : 
-  AsyncChannel(a, b, c, node_)
+P2P::P2P(tcp::socket* a, tcp::socket* b, AsyncNode* node_) : 
+  AsyncChannel(a, b, node_)
 { }
 // }}}
 // is_multiple {{{

--- a/src/network/p2p.hh
+++ b/src/network/p2p.hh
@@ -7,7 +7,7 @@ namespace network {
 // @pre server and client socket should be open and not null
 class P2P: public AsyncChannel {
   public:
-    P2P(tcp::socket*, tcp::socket*, Context&, AsyncNode*);
+    P2P(tcp::socket*, tcp::socket*, AsyncNode*);
     static bool is_multiple();
 };
 

--- a/src/network/server.cc
+++ b/src/network/server.cc
@@ -3,8 +3,8 @@
 using namespace eclipse::network;
 
 // constructor {{{
-Server::Server(tcp::socket*, tcp::socket* s, Context& c, AsyncNode* node_) : 
-  AsyncChannel(s, s, c, node_)
+Server::Server(tcp::socket*, tcp::socket* s, AsyncNode* node_) : 
+  AsyncChannel(s, s, node_)
 { }
 // }}}
 // is_multiple {{{

--- a/src/network/server.hh
+++ b/src/network/server.hh
@@ -6,7 +6,7 @@ namespace network {
 
 class Server: public AsyncChannel {
   public:
-    Server(tcp::socket*,tcp::socket*, Context&, AsyncNode*);
+    Server(tcp::socket*,tcp::socket*, AsyncNode*);
     static bool is_multiple();
 };
 

--- a/src/nodes/node.cc
+++ b/src/nodes/node.cc
@@ -10,13 +10,10 @@ using vec_str    = std::vector<std::string>;
 
 namespace eclipse {
 // Constructor & destructor {{{
-Node::Node(Context& context) : 
+Node::Node() : 
   Machine(context.id),
-  logger    (context.logger.get()),
-  settings (context.settings),
-  ip_of_this(context.settings.getip()),
-  io_service(context.io),
-  port      (context.settings.get<int>("network.port_cache"))
+  logger (context.logger.get()),
+  port   (context.settings.get<int>("network.port_cache"))
 {
 }
 

--- a/src/nodes/node.hh
+++ b/src/nodes/node.hh
@@ -13,18 +13,16 @@ namespace eclipse {
 
 class Node: public Machine {
   public:
-    Node(Context&);
+    Node();
     ~Node();
 
     std::string get_ip () const override;
     virtual bool establish() = 0;
 
   protected:
-    Logger* logger;
     network::Network* network;
-    Settings& settings;
+    Logger* logger;
     std::string ip_of_this;
-    boost::asio::io_service& io_service;
     int port;
 };
 

--- a/src/nodes/peerdfs.cc
+++ b/src/nodes/peerdfs.cc
@@ -26,14 +26,14 @@ using namespace std;
 
 namespace eclipse {
 // Constructor & destructor {{{
-PeerDFS::PeerDFS (Context& context) : Node (context) { 
+PeerDFS::PeerDFS () : Node () { 
   Settings& setted = context.settings;
 
   int port       = setted.get<int>("network.port_cache");
   size           = setted.get<vec_str>("network.nodes").size();
   disk_path      = setted.get<string>("path.scratch");
 
-  network   = new AsyncNetwork<P2P>(this, context, port);
+  network   = new AsyncNetwork<P2P>(this, port);
   boundaries.reset( new Histogram {size, 0});
   boundaries->initialize();
 
@@ -254,8 +254,8 @@ bool PeerDFS::list (messages::FileList* m) {
 bool PeerDFS::format () {
   logger->info ("Formating DFS");
 
-  string fs_path = settings.get<string>("path.scratch");
-  string md_path = settings.get<string>("path.metadata");
+  string fs_path = context.settings.get<string>("path.scratch");
+  string md_path = context.settings.get<string>("path.metadata");
 
   DIR *theFolder = opendir(fs_path.c_str());
   struct dirent *next_file;

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -24,7 +24,7 @@ typedef std::function<void(std::string, std::string)> req_func;
 
 class PeerDFS: public Node, public AsyncNode {
   public:
-    PeerDFS (Context&);
+    PeerDFS ();
     ~PeerDFS ();
 
     bool establish () override;

--- a/src/nodes/remotedfs.cc
+++ b/src/nodes/remotedfs.cc
@@ -7,7 +7,7 @@ using namespace eclipse;
 namespace ph = std::placeholders;
 
 // Constructor {{{
-RemoteDFS::RemoteDFS (Context& c) : Router(c) {
+RemoteDFS::RemoteDFS () : Router() {
   routing_table.insert({"BlockInfo",  bind(&RemoteDFS::insert_block, this, ph::_1)});
   routing_table.insert({"FileInfo",   bind(&RemoteDFS::insert_file, this, ph::_1)});
   routing_table.insert({"FileRequest", bind(&RemoteDFS::request_file, this, ph::_1)});
@@ -21,7 +21,7 @@ RemoteDFS::RemoteDFS (Context& c) : Router(c) {
 // }}}
 // establish {{{
 bool RemoteDFS::establish () {
-  peer  = make_unique<PeerDFS> (context);
+  peer  = make_unique<PeerDFS> ();
   peer_dfs = dynamic_cast<PeerDFS*> (peer.get());
   peer_dfs->establish();
   Router::establish();

--- a/src/nodes/remotedfs.hh
+++ b/src/nodes/remotedfs.hh
@@ -10,7 +10,7 @@ using boost::asio::ip::tcp;
 
 class RemoteDFS: public Router {
   public:
-    RemoteDFS (Context&);
+    RemoteDFS ();
     ~RemoteDFS () = default;
 
     virtual bool establish ();

--- a/src/nodes/router.cc
+++ b/src/nodes/router.cc
@@ -15,9 +15,9 @@ using namespace std;
 
 namespace eclipse {
 // Constructor {{{
-Router::Router(Context& c) : Node (c), context(c) {
+Router::Router() : Node () {
   port = context.settings.get<int>("network.port_mapreduce");
-  network = new AsyncNetwork<Server> (this, context, port);
+  network = new AsyncNetwork<Server> (this, port);
 }
 
 Router::~Router() { }

--- a/src/nodes/router.hh
+++ b/src/nodes/router.hh
@@ -13,7 +13,7 @@ using namespace eclipse::network;
 
 class Router: public Node, public AsyncNode {
   public:
-    Router (Context&);
+    Router ();
     ~Router ();
 
     bool establish() override; 
@@ -24,7 +24,6 @@ class Router: public Node, public AsyncNode {
   protected:
     std::map<std::string, std::function<void(messages::Message*)>> routing_table;
     std::unique_ptr<Node> peer;
-    Context& context;
     int port;
 };
 

--- a/src/targets/node_main.cc
+++ b/src/targets/node_main.cc
@@ -5,10 +5,7 @@
 using namespace eclipse;
 
 int main (int argc, char ** argv) {
-  Context context;
-  context.run();
-
-  RemoteDFS nl (context);
+  RemoteDFS nl;
   nl.establish();
 
   return context.join();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,8 +23,8 @@ units_SOURCES      = $(messages_files) \
                      src/network/channel.cc \
                      src/network/asyncchannel.cc \
                      src/network/p2p.cc \
-										 src/network/connector.cc \
 										 src/network/acceptor.cc \
+										 src/network/connector.cc \
                      src/nodes/machine.cc \
                      src/nodes/node.cc 
 
@@ -36,8 +36,8 @@ nodes_SOURCES   = tests/nodes.cc \
                   src/network/asyncchannel.cc \
                   src/network/p2p.cc \
                   src/network/server.cc \
-                  src/network/connector.cc \
                   src/network/acceptor.cc \
+                  src/network/connector.cc \
                   src/nodes/machine.cc \
                   src/nodes/peerdfs.cc \
                   src/nodes/remotedfs.cc \

--- a/tests/metadata_test.cc
+++ b/tests/metadata_test.cc
@@ -8,9 +8,8 @@ using namespace eclipse;
 using namespace std;
 
 int main() {
-  Context con;
   Directory dir;
-  con.logger->info("==========Start dir test==========");
+  context.logger->info("==========Start dir test==========");
 
   // Basic metadata io example
   dir.init_db();
@@ -96,6 +95,6 @@ int main() {
   dir.display_file_metadata();
   dir.display_block_metadata();
   */
-  con.logger->info("==========End dir test==========");
+  context.logger->info("==========End dir test==========");
   return 0;
 }

--- a/tests/nodes.cc
+++ b/tests/nodes.cc
@@ -8,10 +8,7 @@ int main (int argc, char ** argv) {
 
   std::string input = argv[1];
 
-  Context context(input);
-  context.run();
-
-  RemoteDFS nl (context);
+  RemoteDFS nl;
   nl.establish();
 
   return context.join();

--- a/tests/nodes_test.cc
+++ b/tests/nodes_test.cc
@@ -7,8 +7,8 @@ SUITE(NODES) {
   TEST(BASIC) {
     std::string input (
 "{\"name\":\"Raven cluster eclipseMR file\",\"max_job\":1024,\"log\":{\"type\":\"LOG_LOCAL6\",\"name\":\"ECLIPSE\"},\"path\":{\"filesystem\":\"/home/vicente/eclipse_storage/\",\"scratch\":\"/scratch/vicente/storage\",\"ipc\":\"/scratch/vicente/socket\"},\"cache\":{\"numbin\":100,\"size\":200000,\"concurrency\":1},\"network\":{\"port_mapreduce\":8008,\"port_cache\":8009,\"port_dht\":8010,\"topology\":\"mesh\",\"iface\":\"em1\",\"master\":\"10.20.13.123\",\"nodes\":[\"10.20.13.123\",\"10.20.13.124\",\"10.20.13.125\"]}}");
-    Context context(input);
-    RemoteDFS nl (context);
+    Context context;
+    RemoteDFS nl;
 
     sleep (1);
   }


### PR DESCRIPTION
@DICL/team-eclipse I introduced singleton for the context class in this branch.
It might seems like a bad idea, still all the classes depends on logger, settings and io_service, so it does not matter whether we have a context global object or each class referencing it.

In case that in the future we want to revert it. We can do it, all the changes are in @38d935b0a3315b7689e413e34c4f54b00aea7d3b

In the context.hh we have the object context that we can use it everywhere
context.hh

```

Context& context = Context::connect();

```
