### PR TITLE
Big refactor, changed the internal architecture

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,9 @@ messages_files   = src/messages/boundaries.cc      \
                    src/messages/blockdel.cc        \
                    src/messages/filedel.cc         \
 									 src/messages/formatrequest.cc   \
+									 src/messages/file.cc            \
+									 src/messages/block.cc           \
+									 src/messages/list_files.cc      \
 									 src/messages/fileexist.cc
 
 # libs -----
@@ -48,7 +51,6 @@ eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/nodes/machine.cc \
 											 src/nodes/peerdfs.cc \
 											 src/nodes/local_io.cc \
-											 src/nodes/remotedfs.cc \
 											 src/nodes/router.cc \
 											 src/fs/directory.cc \
 											 src/nodes/node.cc \
@@ -59,6 +61,10 @@ eclipse_node_LDADD  = $(LDADD) -lsqlite3
 dfs_SOURCES         = src/fs/dfs.cc \
                       src/fs/directory.cc \
                       src/fs/main.cc \
+                      src/nodes/peerdfs.cc \
+											 src/nodes/node.cc \
+											 src/nodes/local_io.cc \
+											 src/nodes/machine.cc \
 											$(messages_files)
 
 dfs_LDADD           = $(LDADD) -lsqlite3

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/network/connector.cc \
 											 src/nodes/machine.cc \
 											 src/nodes/peerdfs.cc \
+											 src/nodes/local_io.cc \
 											 src/nodes/remotedfs.cc \
 											 src/nodes/router.cc \
 											 src/fs/directory.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,8 @@ eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/network/acceptor.cc \
 											 src/network/connector.cc \
 											 src/nodes/machine.cc \
-											 src/nodes/peerdfs.cc \
+											 src/nodes/dfs.cc \
+											 src/nodes/dio.cc \
 											 src/nodes/local_io.cc \
 											 src/nodes/router.cc \
 											 src/fs/directory.cc \
@@ -61,10 +62,6 @@ eclipse_node_LDADD  = $(LDADD) -lsqlite3
 dfs_SOURCES         = src/fs/dfs.cc \
                       src/fs/directory.cc \
                       src/fs/main.cc \
-                      src/nodes/peerdfs.cc \
-											 src/nodes/node.cc \
-											 src/nodes/local_io.cc \
-											 src/nodes/machine.cc \
 											$(messages_files)
 
 dfs_LDADD           = $(LDADD) -lsqlite3

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 BRIEFING
 ========
 
-EclipseDFS is a state-of-the-art distribute file system. It was designed to be an essential layer of EclipseMR middle-ware.
-Key feature of EclipseDFS are:
+EclipseDFS is an state-of-the-art distributed file system. It was designed to be an essential layer of EclipseMR middle-ware.
+Key features of EclipseDFS are:
  - Efficient block distribution over the nodes.
  - Fast time response.
  - High efficient balancing algorithm.
@@ -13,7 +13,7 @@ USAGE
 =====
 EclipseDFS default launcher is not included in this repository, if you want to use it you can find it [here][eclipsed].
 
-The reason to not to include the launcher inside the package is to let the user to chose any launcher, options are:
+The reason for not to include the launcher inside the package is to let the user to chose any launcher, options are:
  - systemd/init.d
  - puppet/chef/salt
  
@@ -24,6 +24,15 @@ Once the system is running, you can interact with EclipseDFS with the following 
 
 COMPILING & INSTALLING
 =====================
+Before compiling & installing 
+-----------------------------
+
+EclipseDFS has certain dependencies that normally are already installed such as 
+syslog. For more specific dependencies here is a list with its minimum recommended version:
+ - libboost > 1.40           (ASIO, serialization, and property tree lib)
+ - gcc > 4.9 or clang >= 3.5 (support for c++14)
+ - [optional] libunittest++  (For unit testing)
+
 
 For single user installation for developers
 -------------------------------------------
@@ -56,6 +65,7 @@ AUTHOR
  - __AUTHOR:__ [MooHyeon Nam] [mh]
  - __AUTHOR:__ [WonBae Kim] [wb]
  - __AUTHOR:__ [KiBeom Jin] [kb]
+ - __AUTHOR:__ [Beomseok Nam] [nam]
  - __INSTITUTION:__ [DICL laboratory] [dicl] at [UNIST]
 
 <!-- Links -->
@@ -66,3 +76,4 @@ AUTHOR
 [wb]:       https://github.com/zwigul
 [kb]:       https://github.com/kbjin
 [eclipsed]: https://github.com/DICL/eclipsed
+[nam]:      http://dicl.unist.ac.kr/~bsnam/

--- a/src/common/context.hh
+++ b/src/common/context.hh
@@ -33,3 +33,8 @@ class Context {
 };
 
 extern Context& context;
+
+#define ERROR(X, ...) context.logger->error(X, ##__VA_ARGS__ )
+#define WARN(X, ...) context.logger->warn(X, ##__VA_ARGS__)
+#define INFO(X, ...) context.logger->info(X, ##__VA_ARGS__)
+#define DEBUG(X, ...) context.logger->debug(X, ##__VA_ARGS__)

--- a/src/common/histogram.cc
+++ b/src/common/histogram.cc
@@ -132,7 +132,7 @@ void Histogram::set_count (int index, double count)
 void Histogram::updateboundary()   // update the boundary according to the query counts
 {
     // sum up the count of all bin and divide it by number of servers(query per server)
-    double qps = 0.0;
+    double qps = 0.0;              // query per server
     double temp = 0.0;
     double stmeter = 0.0;
     int j = 0;

--- a/src/common/logger.cc
+++ b/src/common/logger.cc
@@ -88,9 +88,9 @@ void Logger::warn (const char* fmt, ...) {
 void Logger::error (const char* fmt, ...) { 
   va_list ap;
   char msg [256];
-
-  strncpy(msg, fmt, 256 );
-  strncat(msg," [ERR:%m]", 256);
+  strncpy(msg,"ERROR ", 256);
+  strncat(msg, fmt, 256);
+  strncat(msg," ERRSTR:%m", 256);
   va_start(ap, fmt);
   log(LOG_ERR, msg, ap);
   va_end(ap);
@@ -121,8 +121,9 @@ void Logger::error_if (bool cmp, const char* fmt, ...) {
     va_list ap;
     char msg [256];
 
-    strncpy(msg, fmt, 256 );
-    strncat(msg," [ERR:%m]", 256);
+    strncpy(msg,"ERROR ", 256);
+    strncat(msg, fmt, 256 );
+    strncat(msg," ERRSTR:%m", 256);
     va_start(ap, fmt);
     log(LOG_ERR, msg, ap);
     va_end(ap);

--- a/src/fs/dfs.cc
+++ b/src/fs/dfs.cc
@@ -1,4 +1,5 @@
 #include "dfs.hh"
+#include "../messages/block.hh"
 using namespace std;
 using namespace eclipse;
 
@@ -197,8 +198,8 @@ namespace eclipse{
           br.block_name = block_name; 
           br.hash_key   = hash_key; 
           send_message(tmp_socket.get(), &br);
-          auto msg = read_reply<BlockInfo>(tmp_socket.get());
-          f << msg->block.content;
+          auto msg = read_reply<Block>(tmp_socket.get());
+          f << msg->content;
           tmp_socket->close();
         }
 

--- a/src/fs/dfs.cc
+++ b/src/fs/dfs.cc
@@ -86,13 +86,13 @@ namespace eclipse{
         uint32_t block_size = 0;
         unsigned int block_seq = 0;
 
-        FileInfo file_info;
+        File file_info;
         file_info.file_name = file_name;
         file_info.file_hash_key = file_hash_key;
         file_info.replica = replica;
         myfile.seekg(0, myfile.end);
         file_info.file_size = myfile.tellg();
-        BlockInfo block_info;
+        Block block_info;
 
         while(1)
         {
@@ -130,7 +130,9 @@ namespace eclipse{
           block_info.r_node = nodes[(which_server+1+NUM_SERVERS)%NUM_SERVERS];
           block_info.is_committed = 1;
 
-          send_message(socket.get(), &block_info);
+          BlockInfo bi;
+          bi.block = block_info;
+          send_message(socket.get(), &bi);
           auto reply = read_reply<Reply> (socket.get());
 
           if (reply->message != "OK") {
@@ -148,7 +150,9 @@ namespace eclipse{
         }
 
         file_info.num_block = block_seq;
-        send_message(socket.get(), &file_info);
+        FileInfo fi;
+        fi.file = file_info;
+        send_message(socket.get(), &fi);
         auto reply = read_reply<Reply> (socket.get());
         myfile.close();
         socket->close();
@@ -194,7 +198,7 @@ namespace eclipse{
           br.hash_key   = hash_key; 
           send_message(tmp_socket.get(), &br);
           auto msg = read_reply<BlockInfo>(tmp_socket.get());
-          f << msg->content;
+          f << msg->block.content;
           tmp_socket->close();
         }
 
@@ -208,7 +212,7 @@ namespace eclipse{
 
   int DFS::ls(int argc, char* argv[])
   {
-    vector<FileInfo> total; 
+    vector<File> total; 
     string op = "";
     if(argc >= 3)
     {
@@ -221,10 +225,10 @@ namespace eclipse{
       send_message(socket.get(), &file_list);
       auto file_list_reply = read_reply<FileList>(socket.get());
 
-      std::copy(file_list_reply->data.begin(), file_list_reply->data.end(), back_inserter(total));
+      std::copy(file_list_reply->list_of_files.data.begin(), file_list_reply->list_of_files.data.end(), back_inserter(total));
     }
 
-    std::sort(total.begin(), total.end(), [] (const FileInfo& a, const FileInfo& b) {
+    std::sort(total.begin(), total.end(), [] (const File& a, const File& b) {
         return (a.file_name < b.file_name);
         });
 
@@ -327,11 +331,13 @@ namespace eclipse{
         unsigned int block_seq = 0;
         for (auto block_name : fd->blocks) {
           auto tmp_socket = connect(boundaries.get_index(fd->hash_keys[block_seq]));
-          BlockDel bd;
+          Block bd;
           bd.block_name = block_name;
           bd.file_name = file_name;
           bd.block_seq = block_seq++;
-          send_message(tmp_socket.get(), &bd);
+          BlockDel block_to_delete;
+          block_to_delete.block = bd;
+          send_message(tmp_socket.get(), &block_to_delete);
           auto msg = read_reply<Reply>(tmp_socket.get());
           if (msg->message != "OK") {
             cerr << "[ERR] " << block_name << "doesn't exist." << endl;

--- a/src/fs/directory.cc
+++ b/src/fs/directory.cc
@@ -131,7 +131,9 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      context.logger->error("SQL error: %s\n", zErrMsg);
+      if (rc != SQLITE_ERROR)
+        context.logger->error("SQL error: %s\n", zErrMsg);
+
       sqlite3_free(zErrMsg);
     }
     else
@@ -157,7 +159,9 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      context.logger->error("SQL error: %s\n", zErrMsg);
+      if (rc != SQLITE_ERROR)
+        context.logger->error("SQL error: %s\n", zErrMsg);
+
       sqlite3_free(zErrMsg);
     }
     else

--- a/src/fs/directory.cc
+++ b/src/fs/directory.cc
@@ -31,7 +31,7 @@ namespace eclipse{
   int Directory::file_callback(void *file_info, int argc, char **argv, char **azColName)
   {
     int i = 0;
-    auto file = reinterpret_cast<FileInfo*>(file_info);
+    auto file = reinterpret_cast<File*>(file_info);
     file->file_name     = argv[i++];
     file->file_hash_key = atoi(argv[i++]);
     file->file_size     = atoi(argv[i++]);
@@ -43,7 +43,7 @@ namespace eclipse{
   int Directory::block_callback(void *block_info, int argc, char **argv, char **azColName)
   {
     int i = 0;
-    auto block = reinterpret_cast<BlockInfo*>(block_info);
+    auto block = reinterpret_cast<Block*>(block_info);
     block->block_name     = argv[i++];
     block->file_name      = argv[i++];
     block->block_seq      = atoi(argv[i++]);
@@ -69,10 +69,10 @@ namespace eclipse{
 
   int Directory::file_list_callback(void *list, int argc, char **argv, char **azColName)
   {
-    auto file_list = reinterpret_cast<vector<FileInfo>*>(list);
+    auto file_list = reinterpret_cast<vector<File>*>(list);
     for(int i=0; i<argc; i++)
     {
-      FileInfo tmp_file;
+      File tmp_file;
       tmp_file.file_name     = argv[i++];
       tmp_file.file_hash_key = atoi(argv[i++]);
       tmp_file.file_size     = atoi(argv[i++]);
@@ -85,10 +85,10 @@ namespace eclipse{
 
   int Directory::block_list_callback(void *list, int argc, char **argv, char **azColName)
   {
-    auto block_list = reinterpret_cast<vector<BlockInfo>*>(list);
+    auto block_list = reinterpret_cast<vector<Block>*>(list);
     for(int i=0; i<argc; i++)
     {
-      BlockInfo tmp_block;
+      Block tmp_block;
       tmp_block.block_name     = argv[i++];
       tmp_block.file_name      = atoi(argv[i++]);
       tmp_block.block_seq      = atoi(argv[i++]);
@@ -173,7 +173,7 @@ namespace eclipse{
     mutex.unlock();
   }
 
-  void Directory::insert_file_metadata(FileInfo file_info)
+  void Directory::insert_file_metadata(File file_info)
   {
     // Open database
     open_db();
@@ -205,7 +205,7 @@ namespace eclipse{
     sqlite3_close(db);
   }
 
-  void Directory::insert_block_metadata(BlockInfo block_info)
+  void Directory::insert_block_metadata(Block block_info)
   {
     // Open database
     open_db();
@@ -243,7 +243,7 @@ namespace eclipse{
     sqlite3_close(db);
   }
 
-  void Directory::select_file_metadata(string file_name, FileInfo *file_info)
+  void Directory::select_file_metadata(string file_name, File *file_info)
   {
     // Open database
     open_db();
@@ -267,7 +267,7 @@ namespace eclipse{
     sqlite3_close(db);
   }
 
-  void Directory::select_block_metadata(string file_name, unsigned int block_seq, BlockInfo *block_info)
+  void Directory::select_block_metadata(string file_name, unsigned int block_seq, Block *block_info)
   {
     // Open database
     open_db();
@@ -292,7 +292,7 @@ namespace eclipse{
     sqlite3_close(db);
   } 
 
-  void Directory::select_all_file_metadata(vector<FileInfo> &file_list)
+  void Directory::select_all_file_metadata(vector<File> &file_list)
   {
     // Open database
     open_db();
@@ -319,7 +319,7 @@ namespace eclipse{
     mutex.unlock();
   }
 
-  void Directory::select_all_block_metadata(vector<BlockInfo> &block_info)
+  void Directory::select_all_block_metadata(vector<Block> &block_info)
   {
     // Open database
     open_db();
@@ -343,7 +343,7 @@ namespace eclipse{
     sqlite3_close(db);
   } 
 
-  void Directory::update_file_metadata(string file_name, FileInfo file_info)
+  void Directory::update_file_metadata(string file_name, File file_info)
   {
     // Open database
     open_db();
@@ -376,7 +376,7 @@ namespace eclipse{
     sqlite3_close(db);
   }
 
-  void Directory::update_block_metadata(string file_name, unsigned int block_seq, BlockInfo block_info)
+  void Directory::update_block_metadata(string file_name, unsigned int block_seq, Block block_info)
   {
     // Open database
     open_db();

--- a/src/fs/directory.hh
+++ b/src/fs/directory.hh
@@ -8,8 +8,8 @@
 #include <vector>
 #include <mutex>
 #include "../common/context.hh"
-#include "../messages/blockinfo.hh"
-#include "../messages/fileinfo.hh"
+#include "../messages/block.hh"
+#include "../messages/file.hh"
 
 namespace eclipse {
   using namespace messages;
@@ -33,14 +33,14 @@ namespace eclipse {
       ~Directory();
       void open_db();
       void init_db();
-      void insert_file_metadata(FileInfo file_info);
-      void insert_block_metadata(BlockInfo block_info);
-      void select_file_metadata(std::string file_name, FileInfo *file_info);
-      void select_block_metadata(std::string file_name, unsigned int block_seq, BlockInfo *block_info);
-      void select_all_file_metadata(std::vector<FileInfo> &file_list);
-      void select_all_block_metadata(std::vector<BlockInfo> &block_list);
-      void update_file_metadata(std::string file_name, FileInfo file_info);
-      void update_block_metadata(std::string file_name, unsigned int block_seq, BlockInfo block_info);
+      void insert_file_metadata(File file_info);
+      void insert_block_metadata(Block block_info);
+      void select_file_metadata(std::string file_name, File *file_info);
+      void select_block_metadata(std::string file_name, unsigned int block_seq, Block *block_info);
+      void select_all_file_metadata(std::vector<File> &file_list);
+      void select_all_block_metadata(std::vector<Block> &block_list);
+      void update_file_metadata(std::string file_name, File file_info);
+      void update_block_metadata(std::string file_name, unsigned int block_seq, Block block_info);
       void delete_file_metadata(std::string file_name);
       void delete_block_metadata(std::string file_name, unsigned int block_seq);
       void display_file_metadata();

--- a/src/messages/blob.hh
+++ b/src/messages/blob.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace eclipse{
+
+struct blob: public Message {
+  std::string get_type() const override;
+  std::string name;
+  std::string content;
+  uint32_t size;
+};
+  
+}

--- a/src/messages/block.cc
+++ b/src/messages/block.cc
@@ -1,0 +1,5 @@
+#include "block.hh"
+
+using namespace eclipse::messages;
+
+std::string Block::get_type() const { return "Block"; }

--- a/src/messages/block.hh
+++ b/src/messages/block.hh
@@ -1,0 +1,25 @@
+#pragma once
+#include "message.hh"
+#include <cstdint>
+
+namespace eclipse {
+namespace messages {
+
+struct Block: public Message {
+  std::string get_type() const override;
+
+  std::string block_name;
+  std::string file_name;
+  unsigned int block_seq;
+  uint32_t block_hash_key;
+  uint32_t block_size;
+  unsigned int is_inter;
+  std::string node;
+  std::string l_node;
+  std::string r_node;
+  unsigned int is_committed;
+  std::string content;
+};
+
+}
+}

--- a/src/messages/blockdel.cc
+++ b/src/messages/blockdel.cc
@@ -5,7 +5,7 @@ using namespace eclipse::messages;
 
 std::string BlockDel::get_type() const { return "BlockDel"; }
 
-void BlockDel::exec(PeerDFS* p, message_fun f) {
+void BlockDel::exec(FS* p, message_fun f) {
 
   bool ret = p->delete_block(&block);
   Reply* reply = new Reply();

--- a/src/messages/blockdel.cc
+++ b/src/messages/blockdel.cc
@@ -1,6 +1,20 @@
 #include "blockdel.hh"
-namespace eclipse {
-namespace messages {
+#include "reply.hh"
+
+using namespace eclipse::messages;
+
 std::string BlockDel::get_type() const { return "BlockDel"; }
-}
+
+void BlockDel::exec(PeerDFS* p, message_fun f) {
+
+  bool ret = p->delete_block(&block);
+  Reply* reply = new Reply();
+
+  if (ret) {
+    reply->message = "OK";
+  } else {
+    reply->message = "FAIL";
+    reply->details = "Block doesn't exist";
+  }
+  f(reply);
 }

--- a/src/messages/blockdel.hh
+++ b/src/messages/blockdel.hh
@@ -1,15 +1,15 @@
 #pragma once
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct BlockDel: public Executable<PeerDFS> {
+struct BlockDel: public Executable<FS> {
   std::string get_type() const override;
   
   Block block;
-  void exec(PeerDFS*, message_fun) override; 
+  void exec(FS*, message_fun) override; 
 };
 
 }

--- a/src/messages/blockdel.hh
+++ b/src/messages/blockdel.hh
@@ -1,23 +1,15 @@
 #pragma once
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct BlockDel: public Message {
+struct BlockDel: public Executable<PeerDFS> {
   std::string get_type() const override;
   
-  std::string block_name;
-  std::string file_name;
-  unsigned int block_seq;
-  //uint32_t block_hash_key;
-  //uint32_t block_size;
-  //unsigned int is_inter;
-  //std::string node;
-  //std::string l_node;
-  //std::string r_node;
-  //unsigned int is_committed;
-  //std::string content;
+  Block block;
+  void exec(PeerDFS*, message_fun) override; 
 };
 
 }

--- a/src/messages/blockinfo.cc
+++ b/src/messages/blockinfo.cc
@@ -1,5 +1,21 @@
 #include "blockinfo.hh"
+#include "reply.hh"
 
 using namespace eclipse::messages;
 
 std::string BlockInfo::get_type() const { return "BlockInfo"; }
+
+void BlockInfo::exec (PeerDFS* p, message_fun f) {
+  bool ret = p->insert_block(&block);
+  Reply* reply = new Reply();
+
+  if (ret) {
+    reply->message = "OK";
+
+  } else {
+    reply->message = "FAIL";
+    reply->details = "Block already exists";
+  }
+
+  f(reply);
+}

--- a/src/messages/blockinfo.cc
+++ b/src/messages/blockinfo.cc
@@ -5,7 +5,7 @@ using namespace eclipse::messages;
 
 std::string BlockInfo::get_type() const { return "BlockInfo"; }
 
-void BlockInfo::exec (PeerDFS* p, message_fun f) {
+void BlockInfo::exec (FS* p, message_fun f) {
   bool ret = p->insert_block(&block);
   Reply* reply = new Reply();
 

--- a/src/messages/blockinfo.hh
+++ b/src/messages/blockinfo.hh
@@ -1,23 +1,18 @@
 #pragma once
-#include "message.hh"
+#include "executable.hh"
+#include "block.hh"
+#include "../nodes/peerdfs.hh"
 #include <cstdint>
 
 namespace eclipse {
 namespace messages {
-  struct BlockInfo: public Message {
-    std::string get_type() const override;
 
-    std::string block_name;
-    std::string file_name;
-    unsigned int block_seq;
-    uint32_t block_hash_key;
-    uint32_t block_size;
-    unsigned int is_inter;
-    std::string node;
-    std::string l_node;
-    std::string r_node;
-    unsigned int is_committed;
-    std::string content;
-  };
+struct BlockInfo: public Executable<PeerDFS> {
+  std::string get_type() const override;
+
+  Block block;
+  void exec(PeerDFS*, message_fun) override; 
+};
+
 }
 }

--- a/src/messages/blockinfo.hh
+++ b/src/messages/blockinfo.hh
@@ -1,17 +1,17 @@
 #pragma once
 #include "executable.hh"
 #include "block.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <cstdint>
 
 namespace eclipse {
 namespace messages {
 
-struct BlockInfo: public Executable<PeerDFS> {
+struct BlockInfo: public Executable<FS> {
   std::string get_type() const override;
 
   Block block;
-  void exec(PeerDFS*, message_fun) override; 
+  void exec(FS*, message_fun) override; 
 };
 
 }

--- a/src/messages/blockrequest.cc
+++ b/src/messages/blockrequest.cc
@@ -6,7 +6,7 @@ namespace ph = std::placeholders;
 
 std::string BlockRequest::get_type() const { return "BlockRequest"; }
 
-void BlockRequest::on_exec(std::string v, std::string k, message_fun f) {
+void BlockRequest::on_exec(std::string k, std::string v, message_fun f) {
   Block bi;
   bi.block_name = k;
   bi.content = v;

--- a/src/messages/blockrequest.cc
+++ b/src/messages/blockrequest.cc
@@ -13,7 +13,7 @@ void BlockRequest::on_exec(std::string v, std::string k, message_fun f) {
   f(&bi);
 }
 
-void BlockRequest::exec(PeerDFS* p, message_fun f) {
+void BlockRequest::exec(FS* p, message_fun f) {
   p->request(hash_key, block_name, std::bind(&BlockRequest::on_exec, this, 
         ph::_1, ph::_2, f));
 }

--- a/src/messages/blockrequest.cc
+++ b/src/messages/blockrequest.cc
@@ -1,9 +1,19 @@
 #include "blockrequest.hh"
 
-namespace eclipse {
-namespace messages {
+
+using namespace eclipse::messages;
+namespace ph = std::placeholders;
 
 std::string BlockRequest::get_type() const { return "BlockRequest"; }
 
+void BlockRequest::on_exec(std::string v, std::string k, message_fun f) {
+  Block bi;
+  bi.block_name = k;
+  bi.content = v;
+  f(&bi);
 }
+
+void BlockRequest::exec(PeerDFS* p, message_fun f) {
+  p->request(hash_key, block_name, std::bind(&BlockRequest::on_exec, this, 
+        ph::_1, ph::_2, f));
 }

--- a/src/messages/blockrequest.hh
+++ b/src/messages/blockrequest.hh
@@ -1,17 +1,20 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct BlockRequest: public Message {
+struct BlockRequest: public Executable<PeerDFS> {
   BlockRequest () = default;
 
   std::string get_type() const override;
   std::string block_name;
   uint32_t hash_key;
+  void exec(PeerDFS*, message_fun) override; 
+  void on_exec(std::string, std::string, message_fun); 
 };
 
 }

--- a/src/messages/blockrequest.hh
+++ b/src/messages/blockrequest.hh
@@ -1,19 +1,19 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct BlockRequest: public Executable<PeerDFS> {
+struct BlockRequest: public Executable<FS> {
   BlockRequest () = default;
 
   std::string get_type() const override;
   std::string block_name;
   uint32_t hash_key;
-  void exec(PeerDFS*, message_fun) override; 
+  void exec(FS*, message_fun) override; 
   void on_exec(std::string, std::string, message_fun); 
 };
 

--- a/src/messages/boost_impl.cc
+++ b/src/messages/boost_impl.cc
@@ -21,3 +21,6 @@ BOOST_CLASS_EXPORT(eclipse::messages::FileDel);
 BOOST_CLASS_EXPORT(eclipse::messages::BlockDel);
 BOOST_CLASS_EXPORT(eclipse::messages::FormatRequest);
 BOOST_CLASS_EXPORT(eclipse::messages::FileExist);
+BOOST_CLASS_EXPORT(eclipse::messages::File);
+BOOST_CLASS_EXPORT(eclipse::messages::Block);
+BOOST_CLASS_EXPORT(eclipse::messages::List_files);

--- a/src/messages/boost_impl.hh
+++ b/src/messages/boost_impl.hh
@@ -24,6 +24,9 @@
 #include "filedel.hh"
 #include "formatrequest.hh"
 #include "fileexist.hh"
+#include "block.hh"
+#include "file.hh"
+#include "list_files.hh"
 
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/access.hpp>
@@ -77,15 +80,20 @@ template <typename Archive>
 template <typename Archive>
   void serialize (Archive& ar, eclipse::messages::FileInfo& c, unsigned int) {
     ar & BASE_OBJECT(Message, c);
+    ar & BOOST_SERIALIZATION_NVP(c.file);
+  }
+
+template <typename Archive>
+  void serialize (Archive& ar, eclipse::messages::File& c, unsigned int) {
+    ar & BASE_OBJECT(Message, c);
     ar & BOOST_SERIALIZATION_NVP(c.file_name);
     ar & BOOST_SERIALIZATION_NVP(c.file_hash_key);
     ar & BOOST_SERIALIZATION_NVP(c.file_size);
     ar & BOOST_SERIALIZATION_NVP(c.num_block);
     ar & BOOST_SERIALIZATION_NVP(c.replica);
   }
-
 template <typename Archive>
-  void serialize (Archive& ar, eclipse::messages::BlockInfo& c, unsigned int) {
+  void serialize (Archive& ar, eclipse::messages::Block& c, unsigned int) {
     ar & BASE_OBJECT(Message, c);
     ar & BOOST_SERIALIZATION_NVP(c.block_name);  
     ar & BOOST_SERIALIZATION_NVP(c.file_name);  
@@ -101,6 +109,12 @@ template <typename Archive>
   }
 
 template <typename Archive>
+  void serialize (Archive& ar, eclipse::messages::BlockInfo& c, unsigned int) {
+    ar & BASE_OBJECT(Message, c);
+    ar & BOOST_SERIALIZATION_NVP(c.block);  
+  }
+
+template <typename Archive>
   void serialize (Archive& ar, eclipse::messages::Task& c, unsigned int) {
     ar & BASE_OBJECT(Message, c);
     ar & BOOST_SERIALIZATION_NVP(c.id);
@@ -112,7 +126,7 @@ template <typename Archive>
 template <typename Archive>
   void serialize (Archive& ar, eclipse::messages::FileList& c, unsigned int) {
     ar & BASE_OBJECT(Message, c);
-    ar & BOOST_SERIALIZATION_NVP(c.data);
+    ar & BOOST_SERIALIZATION_NVP(c.list_of_files);
   }
 
 template <typename Archive>
@@ -158,9 +172,7 @@ template <typename Archive>
 template <typename Archive>
   void serialize (Archive& ar, eclipse::messages::BlockDel& c, unsigned int) {
     ar & BASE_OBJECT(Message, c);
-    ar & BOOST_SERIALIZATION_NVP(c.file_name);
-    ar & BOOST_SERIALIZATION_NVP(c.block_seq);
-    ar & BOOST_SERIALIZATION_NVP(c.block_name);
+    ar & BOOST_SERIALIZATION_NVP(c.block);
   }
 
 template <typename Archive>
@@ -172,6 +184,12 @@ template <typename Archive>
   void serialize (Archive& ar, eclipse::messages::FileExist& c, unsigned int) {
     ar & BASE_OBJECT(Message, c);
     ar & BOOST_SERIALIZATION_NVP(c.file_name);
+  }
+
+template <typename Archive>
+  void serialize (Archive& ar, eclipse::messages::List_files& c, unsigned int) {
+    ar & BASE_OBJECT(Message, c);
+    ar & BOOST_SERIALIZATION_NVP(c.data);
   }
 }
 }
@@ -197,3 +215,6 @@ BOOST_CLASS_TRACKING(eclipse::messages::FileDel, boost::serialization::track_nev
 BOOST_CLASS_TRACKING(eclipse::messages::BlockDel, boost::serialization::track_never);
 BOOST_CLASS_TRACKING(eclipse::messages::FormatRequest, boost::serialization::track_never);
 BOOST_CLASS_TRACKING(eclipse::messages::FileExist, boost::serialization::track_never);
+BOOST_CLASS_TRACKING(eclipse::messages::File, boost::serialization::track_never);
+BOOST_CLASS_TRACKING(eclipse::messages::Block, boost::serialization::track_never);
+BOOST_CLASS_TRACKING(eclipse::messages::List_files, boost::serialization::track_never);

--- a/src/messages/boundaries.hh
+++ b/src/messages/boundaries.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 #include <vector>
 #include <iostream>
@@ -9,14 +9,14 @@
 namespace eclipse {
 namespace messages {
 
-struct Boundaries: public Executable<PeerDFS> {
+struct Boundaries: public Executable<FS> {
   Boundaries() = default;
   Boundaries(std::vector<uint64_t>);
 
   std::vector<uint64_t> data;
   std::string get_type() const override;
 
-  void exec(PeerDFS* p, message_fun) override { }
+  void exec(FS* p, message_fun) override { }
 };
 
 }

--- a/src/messages/boundaries.hh
+++ b/src/messages/boundaries.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 #include <vector>
 #include <iostream>
@@ -8,12 +9,14 @@
 namespace eclipse {
 namespace messages {
 
-struct Boundaries: public Message {
+struct Boundaries: public Executable<PeerDFS> {
   Boundaries() = default;
   Boundaries(std::vector<uint64_t>);
 
   std::vector<uint64_t> data;
   std::string get_type() const override;
+
+  void exec(PeerDFS* p, message_fun) override { }
 };
 
 }

--- a/src/messages/cacheinfo.hh
+++ b/src/messages/cacheinfo.hh
@@ -1,15 +1,18 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 #include <vector>
 
 namespace eclipse {
 namespace messages {
 
-struct CacheInfo: public Message {
+struct CacheInfo: public Executable<PeerDFS> {
   std::string get_type() const override;
   std::vector<std::string> keys;
+
+  void exec(PeerDFS* p, message_fun) override { }
 };
 
 }

--- a/src/messages/cacheinfo.hh
+++ b/src/messages/cacheinfo.hh
@@ -1,18 +1,18 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 #include <vector>
 
 namespace eclipse {
 namespace messages {
 
-struct CacheInfo: public Executable<PeerDFS> {
+struct CacheInfo: public Executable<FS> {
   std::string get_type() const override;
   std::vector<std::string> keys;
 
-  void exec(PeerDFS* p, message_fun) override { }
+  void exec(FS* p, message_fun) override { }
 };
 
 }

--- a/src/messages/control.hh
+++ b/src/messages/control.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 
 namespace eclipse {
@@ -11,7 +12,7 @@ enum {
   RESTART  = 1,
   PING     = 2
 };
-struct Control: public Message {
+struct Control: public Executable<PeerDFS> {
   public:
     Control () = default;
     Control (int);
@@ -19,6 +20,8 @@ struct Control: public Message {
     std::string get_type() const override;
 
     int type;
+
+    void exec(PeerDFS* p, message_fun) override { }
 };
 
 } /* messages */ 

--- a/src/messages/control.hh
+++ b/src/messages/control.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 
 namespace eclipse {
@@ -12,7 +12,7 @@ enum {
   RESTART  = 1,
   PING     = 2
 };
-struct Control: public Executable<PeerDFS> {
+struct Control: public Executable<FS> {
   public:
     Control () = default;
     Control (int);
@@ -21,7 +21,7 @@ struct Control: public Executable<PeerDFS> {
 
     int type;
 
-    void exec(PeerDFS* p, message_fun) override { }
+    void exec(FS* p, message_fun) override { }
 };
 
 } /* messages */ 

--- a/src/messages/executable.hh
+++ b/src/messages/executable.hh
@@ -1,0 +1,17 @@
+#pragma once
+#include "message.hh"
+#include <functional>
+
+namespace eclipse {
+namespace messages {
+
+using message_fun = std::function<void(Message*)>;
+
+template <typename T>
+struct Executable: public Message {
+  virtual void exec(T*, message_fun) = 0;
+  virtual std::string get_type() const = 0;
+};
+
+}
+}

--- a/src/messages/file.cc
+++ b/src/messages/file.cc
@@ -1,0 +1,5 @@
+#include "file.hh"
+
+using namespace eclipse::messages;
+
+std::string File::get_type() const { return "File"; }

--- a/src/messages/file.hh
+++ b/src/messages/file.hh
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "message.hh"
+
+namespace eclipse {
+namespace messages {
+
+struct File: public Message {
+  File() = default;
+  ~File() = default;
+
+  std::string get_type() const override;
+
+  std::string file_name;
+  uint32_t file_hash_key = 0;
+  uint64_t file_size = 0;
+  unsigned int num_block = 0;
+  unsigned int replica = 0;
+};
+
+}
+}
+

--- a/src/messages/filedel.cc
+++ b/src/messages/filedel.cc
@@ -5,7 +5,7 @@ namespace eclipse {
 namespace messages {
 std::string FileDel::get_type() const { return "FileDel"; }
 
-void FileDel::exec(PeerDFS* p, message_fun f) {
+void FileDel::exec(FS* p, message_fun f) {
   bool ret = p->delete_file(file_name);
   auto* reply = new Reply();
 

--- a/src/messages/filedel.cc
+++ b/src/messages/filedel.cc
@@ -1,7 +1,20 @@
 #include "filedel.hh"
+#include "reply.hh"
 
 namespace eclipse {
 namespace messages {
 std::string FileDel::get_type() const { return "FileDel"; }
+
+void FileDel::exec(PeerDFS* p, message_fun f) {
+  bool ret = p->delete_file(file_name);
+  auto* reply = new Reply();
+
+  if (ret)
+    reply->message = "OK";
+  else 
+    reply->message = "FAIL";
+
+  f(reply);
+}
 }
 }

--- a/src/messages/filedel.hh
+++ b/src/messages/filedel.hh
@@ -1,22 +1,21 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "reply.hh"
+#include "../nodes/peerdfs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct FileDel: public Message {
+struct FileDel: public Executable<PeerDFS> {
   FileDel() = default;
   ~FileDel() = default;
   
   std::string get_type() const override;
 
   std::string file_name;
-  //uint32_t file_id;
-  //uint32_t file_hash_key;
-  //uint64_t file_size;
-  //unsigned int num_block;
-  //unsigned int replica;
+
+  void exec(PeerDFS*, message_fun) override;
 };
 
 }

--- a/src/messages/filedel.hh
+++ b/src/messages/filedel.hh
@@ -2,12 +2,12 @@
 
 #include "executable.hh"
 #include "reply.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct FileDel: public Executable<PeerDFS> {
+struct FileDel: public Executable<FS> {
   FileDel() = default;
   ~FileDel() = default;
   
@@ -15,7 +15,7 @@ struct FileDel: public Executable<PeerDFS> {
 
   std::string file_name;
 
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 };
 
 }

--- a/src/messages/fileexist.cc
+++ b/src/messages/fileexist.cc
@@ -1,7 +1,19 @@
 #include "fileexist.hh"
+#include "reply.hh"
 
-namespace eclipse {
-namespace messages {
+using namespace eclipse::messages;
+
 std::string FileExist::get_type() const { return "FileExist"; }
-}
+
+void FileExist::exec(PeerDFS* p, message_fun f) {
+  bool ret = p->file_exist(file_name);
+  Reply* reply = new Reply();
+
+  if (ret) {
+    reply->message = "TRUE";
+
+  } else {
+    reply->message = "FALSE";
+  }
+  f(reply);
 }

--- a/src/messages/fileexist.cc
+++ b/src/messages/fileexist.cc
@@ -5,7 +5,7 @@ using namespace eclipse::messages;
 
 std::string FileExist::get_type() const { return "FileExist"; }
 
-void FileExist::exec(PeerDFS* p, message_fun f) {
+void FileExist::exec(FS* p, message_fun f) {
   bool ret = p->file_exist(file_name);
   Reply* reply = new Reply();
 

--- a/src/messages/fileexist.hh
+++ b/src/messages/fileexist.hh
@@ -1,15 +1,16 @@
 #pragma once
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct FileExist: public Message {
+struct FileExist: public Executable<PeerDFS> {
   std::string get_type() const override;
+  void exec(PeerDFS*, message_fun) override;
 
   std::string file_name;
 };
 
 }
 }
-

--- a/src/messages/fileexist.hh
+++ b/src/messages/fileexist.hh
@@ -1,13 +1,13 @@
 #pragma once
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct FileExist: public Executable<PeerDFS> {
+struct FileExist: public Executable<FS> {
   std::string get_type() const override;
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 
   std::string file_name;
 };

--- a/src/messages/fileinfo.cc
+++ b/src/messages/fileinfo.cc
@@ -5,7 +5,7 @@ namespace eclipse {
 namespace messages {
 std::string FileInfo::get_type() const { return "FileInfo"; }
 
-void FileInfo::exec(PeerDFS* p, message_fun f) {
+void FileInfo::exec(FS* p, message_fun f) {
   bool ret = p->file_exist(file.file_name);
   Reply* reply = new Reply();
 

--- a/src/messages/fileinfo.cc
+++ b/src/messages/fileinfo.cc
@@ -1,7 +1,23 @@
 #include "fileinfo.hh"
+#include "reply.hh"
 
 namespace eclipse {
 namespace messages {
 std::string FileInfo::get_type() const { return "FileInfo"; }
+
+void FileInfo::exec(PeerDFS* p, message_fun f) {
+  bool ret = p->file_exist(file.file_name);
+  Reply* reply = new Reply();
+
+  if (ret) {
+    reply->message = "TRUE";
+
+  } else {
+    reply->message = "FALSE";
+  }
+
+  f(reply);
+}
+
 }
 }

--- a/src/messages/fileinfo.cc
+++ b/src/messages/fileinfo.cc
@@ -1,23 +1,20 @@
 #include "fileinfo.hh"
 #include "reply.hh"
 
-namespace eclipse {
-namespace messages {
+using namespace eclipse::messages;
+
 std::string FileInfo::get_type() const { return "FileInfo"; }
 
 void FileInfo::exec(FS* p, message_fun f) {
-  bool ret = p->file_exist(file.file_name);
+  bool ret = p->insert_file (&file);
   Reply* reply = new Reply();
 
   if (ret) {
-    reply->message = "TRUE";
+    reply->message = "OK";
 
   } else {
-    reply->message = "FALSE";
+    reply->message = "FAIL";
   }
 
   f(reply);
-}
-
-}
 }

--- a/src/messages/fileinfo.hh
+++ b/src/messages/fileinfo.hh
@@ -1,21 +1,20 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "file.hh"
+#include "../nodes/peerdfs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct FileInfo: public Message {
+struct FileInfo: public Executable<PeerDFS> {
   FileInfo() = default;
   ~FileInfo() = default;
 
   std::string get_type() const override;
 
-  std::string file_name;
-  uint32_t file_hash_key;
-  uint64_t file_size;
-  unsigned int num_block;
-  unsigned int replica;
+  File file;
+  void exec(PeerDFS*, message_fun) override;
 };
 
 }

--- a/src/messages/fileinfo.hh
+++ b/src/messages/fileinfo.hh
@@ -2,19 +2,19 @@
 
 #include "executable.hh"
 #include "file.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 
 namespace eclipse {
 namespace messages {
 
-struct FileInfo: public Executable<PeerDFS> {
+struct FileInfo: public Executable<FS> {
   FileInfo() = default;
   ~FileInfo() = default;
 
   std::string get_type() const override;
 
   File file;
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 };
 
 }

--- a/src/messages/filelist.cc
+++ b/src/messages/filelist.cc
@@ -7,7 +7,7 @@ namespace messages {
 std::string FileList::get_type() const { return "FileList"; }
 
 
-void FileList::exec(PeerDFS* p, message_fun f) {
+void FileList::exec(FS* p, message_fun f) {
   p->list(&list_of_files);
   f(this);
 }

--- a/src/messages/filelist.cc
+++ b/src/messages/filelist.cc
@@ -3,8 +3,14 @@
 namespace eclipse {
 namespace messages {
 
-FileList::FileList (std::vector<FileInfo> v) : data(v) { }
+//FileList::FileList (std::vector<FileInfo> v) : data(v) { }
 std::string FileList::get_type() const { return "FileList"; }
+
+
+void FileList::exec(PeerDFS* p, message_fun f) {
+  p->list(&list_of_files);
+  f(this);
+}
 
 }
 }

--- a/src/messages/filelist.hh
+++ b/src/messages/filelist.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 #include <vector>
 #include <iostream>
@@ -10,13 +10,13 @@
 namespace eclipse {
 namespace messages {
 
-struct FileList: public Executable<PeerDFS> {
+struct FileList: public Executable<FS> {
   FileList() = default;
 
   List_files list_of_files;
 
   std::string get_type() const override;
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 };
 
 }

--- a/src/messages/filelist.hh
+++ b/src/messages/filelist.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 #include <vector>
 #include <iostream>
@@ -9,12 +10,13 @@
 namespace eclipse {
 namespace messages {
 
-struct FileList: public Message {
+struct FileList: public Executable<PeerDFS> {
   FileList() = default;
-  FileList(std::vector<FileInfo>);
+
+  List_files list_of_files;
 
   std::string get_type() const override;
-  std::vector<FileInfo> data;
+  void exec(PeerDFS*, message_fun) override;
 };
 
 }

--- a/src/messages/filerequest.cc
+++ b/src/messages/filerequest.cc
@@ -5,5 +5,10 @@ namespace messages {
 
 std::string FileRequest::get_type() const { return "FileRequest"; }
 
+void FileRequest::exec(PeerDFS* p, message_fun f) {
+  auto fd = p->request_file (file_name);
+  f(&fd);
+}
+
 }
 }

--- a/src/messages/filerequest.cc
+++ b/src/messages/filerequest.cc
@@ -5,7 +5,7 @@ namespace messages {
 
 std::string FileRequest::get_type() const { return "FileRequest"; }
 
-void FileRequest::exec(PeerDFS* p, message_fun f) {
+void FileRequest::exec(FS* p, message_fun f) {
   auto fd = p->request_file (file_name);
   f(&fd);
 }

--- a/src/messages/filerequest.hh
+++ b/src/messages/filerequest.hh
@@ -1,16 +1,19 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct FileRequest: public Message {
+struct FileRequest: public Executable<PeerDFS> {
   FileRequest () = default;
 
   std::string get_type() const override;
   std::string file_name;
+  void exec(PeerDFS*, message_fun) override;
+
 };
 
 }

--- a/src/messages/filerequest.hh
+++ b/src/messages/filerequest.hh
@@ -1,18 +1,18 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct FileRequest: public Executable<PeerDFS> {
+struct FileRequest: public Executable<FS> {
   FileRequest () = default;
 
   std::string get_type() const override;
   std::string file_name;
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 
 };
 

--- a/src/messages/formatrequest.cc
+++ b/src/messages/formatrequest.cc
@@ -1,9 +1,21 @@
 #include "formatrequest.hh"
+#include "reply.hh"
 
-namespace eclipse {
-namespace messages {
+using namespace eclipse::messages;
 
 std::string FormatRequest::get_type() const { return "FormatRequest"; }
 
-}
+void FormatRequest::exec(PeerDFS* p, message_fun f) {
+  bool ret = p->format();
+  Reply* reply = new Reply();
+
+  if (ret) {
+    reply->message = "OK";
+
+  } else {
+    reply->message = "FAIL";
+    reply->details = "File already exists";
+  }
+  f(reply);
+
 }

--- a/src/messages/formatrequest.cc
+++ b/src/messages/formatrequest.cc
@@ -5,7 +5,7 @@ using namespace eclipse::messages;
 
 std::string FormatRequest::get_type() const { return "FormatRequest"; }
 
-void FormatRequest::exec(PeerDFS* p, message_fun f) {
+void FormatRequest::exec(FS* p, message_fun f) {
   bool ret = p->format();
   Reply* reply = new Reply();
 

--- a/src/messages/formatrequest.hh
+++ b/src/messages/formatrequest.hh
@@ -1,18 +1,18 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct FormatRequest: public Executable<PeerDFS> {
+struct FormatRequest: public Executable<FS> {
   FormatRequest () = default;
 
   std::string get_type() const override;
 
-  virtual void exec(PeerDFS* p, message_fun f) override;
+  virtual void exec(FS* p, message_fun f) override;
 };
 
 }

--- a/src/messages/formatrequest.hh
+++ b/src/messages/formatrequest.hh
@@ -1,15 +1,18 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct FormatRequest: public Message {
+struct FormatRequest: public Executable<PeerDFS> {
   FormatRequest () = default;
 
   std::string get_type() const override;
+
+  virtual void exec(PeerDFS* p, message_fun f) override;
 };
 
 }

--- a/src/messages/keyrequest.cc
+++ b/src/messages/keyrequest.cc
@@ -7,7 +7,7 @@ KeyRequest::KeyRequest (std::string k) : key(k) { }
 
 std::string KeyRequest::get_type() const { return "KeyRequest"; }
 
-void KeyRequest::exec(PeerDFS* p, message_fun f) {
+void KeyRequest::exec(FS* p, message_fun f) {
   p->request_key(key, origin);
 }
 

--- a/src/messages/keyrequest.cc
+++ b/src/messages/keyrequest.cc
@@ -7,5 +7,9 @@ KeyRequest::KeyRequest (std::string k) : key(k) { }
 
 std::string KeyRequest::get_type() const { return "KeyRequest"; }
 
+void KeyRequest::exec(PeerDFS* p, message_fun f) {
+  p->request_key(key, origin);
+}
+
 }
 }

--- a/src/messages/keyrequest.hh
+++ b/src/messages/keyrequest.hh
@@ -1,19 +1,19 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct KeyRequest: public Executable<PeerDFS> {
+struct KeyRequest: public Executable<FS> {
   KeyRequest () = default;
   KeyRequest (std::string);
 
   std::string get_type() const override;
   std::string key;
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 };
 
 }

--- a/src/messages/keyrequest.hh
+++ b/src/messages/keyrequest.hh
@@ -1,17 +1,19 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct KeyRequest: public Message {
+struct KeyRequest: public Executable<PeerDFS> {
   KeyRequest () = default;
   KeyRequest (std::string);
 
   std::string get_type() const override;
   std::string key;
+  void exec(PeerDFS*, message_fun) override;
 };
 
 }

--- a/src/messages/keyvalue.cc
+++ b/src/messages/keyvalue.cc
@@ -7,5 +7,9 @@ KeyValue::KeyValue (uint32_t k, std::string n, std::string v) : key(k), name(n),
 
 std::string KeyValue::get_type() const { return "KeyValue"; }
 
+void KeyValue::exec(PeerDFS* p, message_fun f) { 
+  p->insert_key(key, name, value);
+}
+
 }
 }

--- a/src/messages/keyvalue.cc
+++ b/src/messages/keyvalue.cc
@@ -7,7 +7,7 @@ KeyValue::KeyValue (uint32_t k, std::string n, std::string v) : key(k), name(n),
 
 std::string KeyValue::get_type() const { return "KeyValue"; }
 
-void KeyValue::exec(PeerDFS* p, message_fun f) { 
+void KeyValue::exec(FS* p, message_fun f) { 
   p->insert_key(key, name, value);
 }
 

--- a/src/messages/keyvalue.hh
+++ b/src/messages/keyvalue.hh
@@ -1,20 +1,20 @@
 #pragma once
 
 #include "executable.hh"
-#include "../nodes/peerdfs.hh"
+#include "../nodes/fs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct KeyValue: public Executable<PeerDFS> {
+struct KeyValue: public Executable<FS> {
   KeyValue () = default;
   KeyValue (uint32_t, std::string, std::string);
 
   std::string get_type() const override;
   uint32_t key;
   std::string name, value;
-  void exec(PeerDFS*, message_fun) override;
+  void exec(FS*, message_fun) override;
 };
 
 }

--- a/src/messages/keyvalue.hh
+++ b/src/messages/keyvalue.hh
@@ -1,18 +1,20 @@
 #pragma once
 
-#include "message.hh"
+#include "executable.hh"
+#include "../nodes/peerdfs.hh"
 #include <string>
 
 namespace eclipse {
 namespace messages {
 
-struct KeyValue: public Message {
+struct KeyValue: public Executable<PeerDFS> {
   KeyValue () = default;
   KeyValue (uint32_t, std::string, std::string);
 
   std::string get_type() const override;
   uint32_t key;
   std::string name, value;
+  void exec(PeerDFS*, message_fun) override;
 };
 
 }

--- a/src/messages/list_files.cc
+++ b/src/messages/list_files.cc
@@ -1,0 +1,5 @@
+#include "list_files.hh"
+
+using namespace eclipse::messages;
+
+std::string List_files::get_type() const { return "List_files"; }

--- a/src/messages/list_files.hh
+++ b/src/messages/list_files.hh
@@ -1,0 +1,21 @@
+#pragma once
+#include "message.hh"
+#include <string>
+#include <vector>
+#include <iostream>
+#include "file.hh"
+
+
+namespace eclipse {
+namespace messages {
+
+struct List_files: public Message {
+  List_files() = default;
+  List_files(std::vector<File>);
+
+  std::string get_type() const override;
+  std::vector<File> data;
+};
+
+}
+}

--- a/src/messages/path.hh
+++ b/src/messages/path.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace eclipse {
+namespace messages {
+
+struct Path: public Message {
+  std::string path_;
+};
+
+}
+}

--- a/src/network/asyncchannel.cc
+++ b/src/network/asyncchannel.cc
@@ -46,38 +46,34 @@ void AsyncChannel::do_write_impl (string* to_write) {
 }
 // }}}
 // on_write {{{
-void AsyncChannel::on_write (const boost::system::error_code& ec, 
-    size_t s, string* str) {
+void AsyncChannel::on_write (const error_code& ec, size_t s, string* str) {
   delete str;
   if (ec) {
-    logger->info ("Message could not reach err=%s", 
-        ec.message().c_str());
-
+    INFO("Message could not reach err=%s", ec.message().c_str());
     do_write_impl(str);
   }
 }
 // }}}
 // do_read {{{
 void AsyncChannel::do_read () {
-  logger->info("Connection established, starting to read");
+  DEBUG("Connection established, starting to read");
   spawn(iosvc, bind(&AsyncChannel::read_coroutine, this, _1));
 }
 // }}}
 // read_coroutine {{{
 void AsyncChannel::read_coroutine (yield_context yield) {
-  boost::asio::streambuf body; 
-  boost::system::error_code ec;
-  char header [header_size + 1]; 
-  header[16] = '\0';
-
   try {
+    boost::asio::streambuf body; 
+    boost::system::error_code ec;
+    char header [header_size + 1] = {'\0'}; 
+    header[16] = '\0';
+
     while (true) {
       size_t l = async_read (*receiver, buffer(header, header_size), yield[ec]);
-      if (l != (size_t)header_size or ec) throw 1;
+      if (l != (size_t)header_size or ec) throw ec;
 
       size_t size = atoi(header);
       l = read (*receiver, body.prepare(size));
-      //if (ec) throw 1;
 
       body.commit (l);
       string str ((istreambuf_iterator<char>(&body)), 
@@ -90,14 +86,18 @@ void AsyncChannel::read_coroutine (yield_context yield) {
       delete msg;
       msg=nullptr;
     }
-  } catch (...) {
+  } catch (boost::system::error_code& ec) {
     if (ec == boost::asio::error::eof)
-      logger->info ("AsyncChannel: Closing server socket to client");
+      INFO("AsyncChannel: Closing server socket to client");
+
     else
-      logger->info ("AsyncChannel: Message arrived error=%s", 
+      ERROR("AsyncChannel: Message arrived error=%s", 
           ec.message().c_str());
 
-      node->on_disconnect(nullptr, id);
+  } catch (std::exception& e) {
+      INFO("AsyncChannel: Exception raised");
   }
+
+  node->on_disconnect(nullptr, id);
 }
 // }}}

--- a/src/network/asyncchannel.cc
+++ b/src/network/asyncchannel.cc
@@ -46,7 +46,7 @@ void AsyncChannel::do_write_impl (string* to_write) {
 }
 // }}}
 // on_write {{{
-void AsyncChannel::on_write (const error_code& ec, size_t s, string* str) {
+void AsyncChannel::on_write (const boost::system::error_code& ec, size_t s, string* str) {
   delete str;
   if (ec) {
     INFO("Message could not reach err=%s", ec.message().c_str());

--- a/src/network/asyncnetwork.hh
+++ b/src/network/asyncnetwork.hh
@@ -17,17 +17,20 @@ using boost::asio::ip::tcp;
 template<typename TYPE>
 class AsyncNetwork: public Network, public NetObserver {
   public:
-    AsyncNetwork(AsyncNode*, int);
+    AsyncNetwork(int);
     ~AsyncNetwork ();
 
     bool establish() override;
     bool close () override;
     size_t size () override;
     bool send(int, messages::Message*) override;
+    void attach(AsyncNode*) override;
+
     void on_accept(tcp::socket*) override;
     void on_connect(tcp::socket*) override;
     void on_disconnect(tcp::socket*, int) override;
     void on_read(messages::Message*, int) override;
+
 
   private:
     int id_of(tcp::socket*);
@@ -48,8 +51,7 @@ class AsyncNetwork: public Network, public NetObserver {
 };
 // Constructor {{{
 template<typename TYPE>
-AsyncNetwork<TYPE>::AsyncNetwork (AsyncNode* n, int port):
-  node(n),
+AsyncNetwork<TYPE>::AsyncNetwork (int port):
   nodes(context.settings.get<vec_str> ("network.nodes")),
   acceptor(port, this),
   connector(port, this),
@@ -193,6 +195,12 @@ void AsyncNetwork<TYPE>::start_reading () {
 template <typename TYPE>
 void AsyncNetwork<TYPE>::on_read (messages::Message* m , int id) {
   node->on_read(m, id);
+}
+// }}}
+// attach {{{
+template <typename TYPE>
+void AsyncNetwork<TYPE>::attach (AsyncNode* node_) {
+  node = node_;
 }
 // }}}
 }

--- a/src/network/asyncnetwork.hh
+++ b/src/network/asyncnetwork.hh
@@ -89,9 +89,8 @@ size_t AsyncNetwork<TYPE>::size () {
 // send {{{
 template<typename TYPE>
 bool AsyncNetwork<TYPE>::send (int i, messages::Message* m) {
-  acceptor_mutex.lock(); 
+  std::lock_guard<std::mutex> lck (acceptor_mutex); 
   channels[i]->do_write(m);
-  acceptor_mutex.unlock(); 
   return true;
 }
 // }}}
@@ -99,11 +98,10 @@ bool AsyncNetwork<TYPE>::send (int i, messages::Message* m) {
 template<typename TYPE>
 void AsyncNetwork<TYPE>::on_accept (tcp::socket* sock) {
   if (not TYPE::is_multiple()) {
-    acceptor_mutex.lock(); 
+    std::lock_guard<std::mutex> lck (acceptor_mutex); 
     channels.emplace (accepted_size.load(), std::make_unique<TYPE> (sock, sock, this, accepted_size.load()));
     accepted_size++;
     channels[accepted_size.load() - 1]->do_read();
-    acceptor_mutex.unlock(); 
 
   } else {
     auto i = id_of (sock);
@@ -142,9 +140,8 @@ void AsyncNetwork<TYPE>::on_disconnect (tcp::socket* sock, int id) {
 
   accepted_size--;
 
-  acceptor_mutex.lock(); 
+  std::lock_guard<std::mutex> lck (acceptor_mutex); 
   channels.erase(id);
-  acceptor_mutex.unlock(); 
 }
 // }}}
 // completed_network {{{

--- a/src/network/asyncnetwork.hh
+++ b/src/network/asyncnetwork.hh
@@ -12,6 +12,7 @@ namespace eclipse {
 namespace network {
 
 using vec_str = std::vector<std::string>;
+template <typename T> using u_ptr = std::unique_ptr<T>;
 using boost::asio::ip::tcp;
 
 template<typename TYPE>

--- a/src/network/network.hh
+++ b/src/network/network.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "../messages/message.hh"
+#include "asyncnode.hh"
 
 namespace eclipse {
 namespace network {
@@ -12,6 +13,7 @@ class Network {
     virtual bool close () = 0;
     virtual size_t size () = 0;
     virtual bool send(int, messages::Message*) = 0;
+    virtual void attach (AsyncNode*) = 0;
 };
 
 }

--- a/src/nodes/blocksystem.hh
+++ b/src/nodes/blocksystem.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "block.hh"
+
+
+struct BlockSystem {
+  void insert (Blob*) = 0;
+  void open (Blob*) = 0;
+  void exists (Blob*) = 0;
+  void rename (Blob*) = 0;
+  void remove (Blob*) = 0;
+  void format (Blob*) = 0;
+  void list (Blob*) = 0;
+};

--- a/src/nodes/dbs.hh
+++ b/src/nodes/dbs.hh
@@ -1,0 +1,25 @@
+#pragma once
+#include "io_interface.hh"
+
+namespace eclipse {
+
+class DBS: public IO_interface {
+  public:
+    DBS(DIO*);
+    ~DBS();
+
+    bool insert (Blob*) override;
+    bool open (Blob*) override;
+    bool exists (Blob*) override;
+    BlobInfo info (Blob*) override;
+    bool rename (Blob*) override;
+    bool remove (Blob*) override;
+    bool format () override;
+    bool list () override;
+
+  protected:
+    Directory directory;
+    DIO* dio;
+};
+
+}

--- a/src/nodes/dfs.cc
+++ b/src/nodes/dfs.cc
@@ -1,0 +1,118 @@
+#include "dfs.hh"
+#include "../common/context.hh"
+
+using namespace eclipse;
+
+DFS::DFS(DIO* dio_): dio(dio_) {
+  directory.init_db();
+}
+DFS::~DFS() { }
+// insert_file {{{
+bool DFS::insert_file (messages::File* f) {
+ bool ret = directory.file_exist(f->file_name.c_str());
+
+ if (ret) {
+   INFO("File:%s exists in db, ret = %i", f->file_name.c_str(), ret);
+   return false;
+ }
+
+ directory.insert_file_metadata(*f);
+
+ INFO("Saving to SQLite db");
+ return true;
+}
+// }}}
+// insert_block {{{
+bool DFS::insert_block (messages::Block* m) {
+  string key = m->block_name;
+  directory.insert_block_metadata(*m);
+  dio->insert(m->block_hash_key, key, m->content);
+  return true;
+}
+// }}}
+// delete_block {{{
+bool DFS::delete_block (messages::Block* m) {
+  string file_name = m->file_name;
+  unsigned int block_seq = m->block_seq;
+  string key = m->block_name;
+  dio->local_io.remove(key);
+  directory.delete_block_metadata(file_name, block_seq);
+  return true;
+}
+// }}}
+// delete_file {{{
+bool DFS::delete_file (std::string file_name) {
+  bool ret = directory.file_exist(file_name.c_str());
+
+  if (!ret) {
+    INFO("File:%s doesn't exist in db, ret = %i", file_name.c_str(), ret);
+    return false;
+  }
+ 
+  directory.delete_file_metadata(file_name);
+ 
+  INFO("Removing from SQLite db");
+  return true;
+}
+// }}}
+// request_file {{{
+FileDescription DFS::request_file (std::string file_name) {
+  File fi;
+  fi.num_block = 0;
+  FileDescription fd;
+  fd.file_name  = file_name;
+
+  directory.select_file_metadata(file_name, &fi);
+
+  int num_blocks = fi.num_block;
+  for (int i = 0; i< num_blocks; i++) {
+    Block bi;
+    directory.select_block_metadata (file_name, i, &bi);
+    string block_name = bi.block_name;
+    fd.blocks.push_back(block_name);
+    fd.hash_keys.push_back(bi.block_hash_key);
+  }
+
+  return fd;
+}
+// }}}
+// list {{{
+bool DFS::list (messages::List_files* m) {
+  directory.select_all_file_metadata(m->data);
+  return true;
+}
+// }}}
+// format {{{
+bool DFS::format () {
+  INFO("Formating DFS");
+  dio->local_io.format();
+  directory.init_db();
+  return true;
+}
+// }}}
+// file_exist {{{
+// FIXME need to think better name for this function
+/**
+ *@brief check we have given file name on our database
+ *@param f is file name
+ *@return return true if found that file on database otherwise return false
+ */
+bool DFS::file_exist (std::string file_name) {
+  return directory.file_exist(file_name.c_str());
+}
+// }}}
+// insert_key {{{
+void DFS::insert_key (uint32_t key, std::string name, std::string value) {
+  dio->insert_key(key, name, value);
+}
+// }}}
+// request_key {{{
+void DFS::request_key (std::string key, int origin) {
+  dio->request_key(key, origin);
+}
+// }}}
+// request {{{
+void DFS::request (uint32_t key, string name , req_func f) {
+  dio->request(key, name, f);
+}
+// }}}

--- a/src/nodes/dfs.hh
+++ b/src/nodes/dfs.hh
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "dio.hh"
+#include "../messages/file.hh"
+#include "../messages/block.hh"
+#include "../messages/file_long.hh"
+#include "../messages/file_list.hh"
+#include "../fs/directory.hh"
+#include <string>
+
+namespace eclipse {
+
+class DFS {
+  public:
+    DFS (DIO*);
+    ~DFS ();
+
+    bool insert_block (messages::Block*);
+    bool insert_file (messages::File*);
+    bool delete_block (messages::Block*);
+    bool delete_file (std::string);
+    bool list (messages::FileList*);
+    bool format ();
+    FileDescription request_file (std::string);
+    bool file_exist (std::string);
+
+  protected:
+    Directory directory;
+    DIO* DIO_;
+};
+
+}

--- a/src/nodes/dfs.hh
+++ b/src/nodes/dfs.hh
@@ -1,32 +1,32 @@
 #pragma once
 
 #include "dio.hh"
-#include "../messages/file.hh"
-#include "../messages/block.hh"
-#include "../messages/file_long.hh"
-#include "../messages/file_list.hh"
+#include "fs.hh"
 #include "../fs/directory.hh"
 #include <string>
 
 namespace eclipse {
 
-class DFS {
+class DFS: public FS {
   public:
     DFS (DIO*);
     ~DFS ();
 
-    bool insert_block (messages::Block*);
-    bool insert_file (messages::File*);
-    bool delete_block (messages::Block*);
-    bool delete_file (std::string);
-    bool list (messages::FileList*);
-    bool format ();
-    FileDescription request_file (std::string);
-    bool file_exist (std::string);
+    bool insert_block (messages::Block*) override;
+    bool insert_file (messages::File*) override;
+    bool delete_block (messages::Block*) override;
+    bool delete_file (std::string) override;
+    bool list (messages::List_files*) override;
+    bool format () override;
+    messages::FileDescription request_file (std::string) override;
+    bool file_exist (std::string) override;
+    void insert_key (uint32_t, std::string, std::string) override;
+    void request_key (std::string, int) override;
+    void request (uint32_t, std::string, req_func) override;
 
   protected:
     Directory directory;
-    DIO* DIO_;
+    DIO* dio;
 };
 
 }

--- a/src/nodes/dio.cc
+++ b/src/nodes/dio.cc
@@ -1,5 +1,5 @@
 // includes & usings {{{
-#include "peerdfs.hh"
+#include "dio.hh"
 #include "../messages/factory.hh"
 #include "../messages/boost_impl.hh"
 #include "../messages/keyrequest.hh"
@@ -17,7 +17,7 @@ using namespace std;
 
 namespace eclipse {
 // Constructor & destructor {{{
-PeerDFS::PeerDFS (Network* net) : Node () { 
+DIO::DIO (Network* net) : Node () { 
   network = net;
 
   int size = context.settings.get<vec_str>("network.nodes").size();
@@ -25,10 +25,10 @@ PeerDFS::PeerDFS (Network* net) : Node () {
   boundaries->initialize();
 }
 
-PeerDFS::~PeerDFS() { }
+DIO::~DIO() { }
 // }}}
 // insert {{{
-void PeerDFS::insert (uint32_t hash_key, std::string name, std::string v) {
+void DIO::insert (uint32_t hash_key, std::string name, std::string v) {
   int which_node = boundaries->get_index(hash_key);
 
   if (which_node == id) {
@@ -43,7 +43,7 @@ void PeerDFS::insert (uint32_t hash_key, std::string name, std::string v) {
 }
 // }}}
 // request {{{
-void PeerDFS::request (uint32_t key, string name , req_func f) {
+void DIO::request (uint32_t key, string name , req_func f) {
  int idx = boundaries->get_index(key);
 
  if (idx != id) {
@@ -59,10 +59,10 @@ void PeerDFS::request (uint32_t key, string name , req_func f) {
 }
 // }}}
 // close {{{
-void PeerDFS::close() { exit(EXIT_SUCCESS); }
+void DIO::close() { exit(EXIT_SUCCESS); }
 // }}}
 // insert_key {{{
-void PeerDFS::insert_key (uint32_t key, std::string name, std::string value) {
+void DIO::insert_key (uint32_t key, std::string name, std::string value) {
   int which_node = boundaries->get_index(key);
   if (which_node == id)  {
     logger->info ("Instering key = %s", name.c_str());
@@ -77,7 +77,7 @@ void PeerDFS::insert_key (uint32_t key, std::string name, std::string value) {
 }
 // }}}
 // request_key {{{
-void PeerDFS::request_key (std::string key, int origin) {
+void DIO::request_key (std::string key, int origin) {
   INFO("Arrived req key = %s", key.c_str());
   string value = local_io.read(key);
 

--- a/src/nodes/dio.hh
+++ b/src/nodes/dio.hh
@@ -11,10 +11,10 @@ namespace eclipse {
 using vec_str = std::vector<std::string>;
 typedef std::function<void(std::string, std::string)> req_func;
 
-class PeerDFS: public Node {
+class DIO: public Node {
   public:
-    PeerDFS (network::Network*);
-    ~PeerDFS ();
+    DIO (network::Network*);
+    ~DIO ();
 
     void insert_key (uint32_t, std::string, std::string);
     void request_key (std::string, int);

--- a/src/nodes/eclipsedfs.hh
+++ b/src/nodes/eclipsedfs.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace eclipse {
+
+class EclipseDFS: public System {
+  public:
+    EclipseDFS(DFS*, DBS*);
+    DFS* get_dfs();
+    DBS* get_dio();
+
+  private:
+    DFS* dfs;
+    DBS* dio;
+};
+  
+} /* eclipse  */ 
+
+
+

--- a/src/nodes/filesystem.hh
+++ b/src/nodes/filesystem.hh
@@ -1,0 +1,27 @@
+#pragma once
+#include "io_interface.hh"
+#include "dio.hh"
+
+namespace eclipse {
+
+class DFS: public IO_interface {
+  public:
+    DFS (DIO*);
+    ~DFS();
+
+    bool insert (Blob*) override;
+    Blob* open (Path*) override;
+    bool exists (Path*) override;
+    Blob info (Path*) override;
+    bool rename (Path*, Path*) override;
+    bool remove (Path*) override;
+    bool format () override;
+    bool list () override;
+
+  protected:
+    Directory directory;
+    DIO* dio;
+    //DBS* dbs;
+};
+
+}

--- a/src/nodes/fs.hh
+++ b/src/nodes/fs.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../messages/file.hh"
+#include "../messages/block.hh"
+#include "../messages/filedescription.hh"
+#include "../messages/list_files.hh"
+#include <string>
+
+namespace eclipse {
+typedef std::function<void(std::string, std::string)> req_func;
+
+struct FS {
+  virtual bool insert_block (messages::Block*) = 0;
+  virtual bool insert_file (messages::File*) = 0;
+  virtual bool delete_block (messages::Block*) = 0;
+  virtual bool delete_file (std::string) = 0;
+  virtual bool list (messages::List_files*) = 0;
+  virtual bool format () = 0;
+  virtual messages::FileDescription request_file (std::string) = 0;
+  virtual bool file_exist (std::string) = 0;
+  virtual void insert_key (uint32_t, std::string, std::string) = 0;
+  virtual void request_key (std::string, int) = 0;
+  virtual void request (uint32_t, std::string, req_func) = 0;
+};
+
+}

--- a/src/nodes/io_interface.hh
+++ b/src/nodes/io_interface.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+struct IO_interface {
+  void insert (Blob*) = 0;
+  void open (Blob*) = 0;
+  void exists (Blob*) = 0;
+  void rename (Blob*) = 0;
+  void remove (Blob*) = 0;
+  void format (Blob*) = 0;
+  void list (Blob*) = 0;
+};

--- a/src/nodes/local_io.cc
+++ b/src/nodes/local_io.cc
@@ -7,9 +7,11 @@
 using namespace eclipse;
 using namespace std;
 
+// constructors {{{
 Local_io::Local_io() {
   disk_path = context.settings.get<string>("path.scratch");
 }
+//  }}}
 // write {{{
 void Local_io::write (std::string name, std::string v) {
   string file_path = disk_path + string("/") + name;

--- a/src/nodes/local_io.cc
+++ b/src/nodes/local_io.cc
@@ -1,0 +1,55 @@
+#include "local_io.hh"
+#include "../common/context.hh"
+#include <cstdio>
+#include <dirent.h>
+#include <fstream>
+
+using namespace eclipse;
+using namespace std;
+
+Local_io::Local_io() {
+  disk_path = context.settings.get<string>("path.scratch");
+}
+// write {{{
+void Local_io::write (std::string name, std::string v) {
+  string file_path = disk_path + string("/") + name;
+  ofstream file (file_path);
+  file << v;
+  file.close();
+}
+// }}}
+// read {{{
+std::string Local_io::read (string name) {
+  ifstream in (disk_path + string("/") + name);
+  string value ((std::istreambuf_iterator<char>(in)),
+      std::istreambuf_iterator<char>());
+
+  in.close();
+  return value;
+}
+// }}}
+// format {{{
+bool Local_io::format () {
+  string fs_path = context.settings.get<string>("path.scratch");
+  string md_path = context.settings.get<string>("path.metadata");
+
+  DIR *theFolder = opendir(fs_path.c_str());
+  struct dirent *next_file;
+  char filepath[256] = {0};
+
+  while ( (next_file = readdir(theFolder)) != NULL ) {
+    sprintf(filepath, "%s/%s", fs_path.c_str(), next_file->d_name);
+    remove(filepath);
+  }
+  closedir(theFolder);
+
+  ::remove((md_path + "/metadata.db").c_str());
+  return true;
+}
+// }}}
+// remove {{{
+void Local_io::remove (std::string k) {
+  string file_path = disk_path + string("/") + k;
+  ::remove(file_path.c_str());
+}
+// }}}

--- a/src/nodes/local_io.hh
+++ b/src/nodes/local_io.hh
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+
+namespace eclipse {
+
+class Local_io {
+  public:
+    void write (std::string, std::string);
+    std::string read (std::string);
+    void remove (std::string);
+    bool format ();
+
+    Local_io();
+   
+  private:
+    std::string disk_path;
+};
+
+}

--- a/src/nodes/node.hh
+++ b/src/nodes/node.hh
@@ -17,7 +17,6 @@ class Node: public Machine {
     ~Node();
 
     std::string get_ip () const override;
-    virtual bool establish() = 0;
 
   protected:
     network::Network* network;

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "node.hh"
+#include "local_io.hh"
 #include "../network/asyncnode.hh"
 #include "../messages/blockinfo.hh"
 #include "../messages/fileinfo.hh"
@@ -35,7 +36,6 @@ class PeerDFS: public Node, public AsyncNode {
     virtual void insert (uint32_t, std::string, std::string);
     virtual void request (uint32_t, std::string, req_func);
 
-    void Delete (std::string);
     void close ();
     bool insert_block (messages::BlockInfo*);
     bool insert_file (messages::FileInfo*);
@@ -48,6 +48,7 @@ class PeerDFS: public Node, public AsyncNode {
 
   protected:
     Directory directory;
+    Local_io local_io;
     std::unique_ptr<Histogram> boundaries;
     std::map<std::string, req_func> requested_blocks;
     bool connected = false;

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -25,10 +25,9 @@ typedef std::function<void(std::string, std::string)> req_func;
 
 class PeerDFS: public Node, public AsyncNode {
   public:
-    PeerDFS ();
+    PeerDFS (network::Network*);
     ~PeerDFS ();
 
-    bool establish () override;
     void on_read (messages::Message*, int) override;
     void on_connect () override;
     void on_disconnect(int) override;
@@ -51,9 +50,6 @@ class PeerDFS: public Node, public AsyncNode {
     Local_io local_io;
     std::unique_ptr<Histogram> boundaries;
     std::map<std::string, req_func> requested_blocks;
-    bool connected = false;
-    int size;
-    std::string disk_path;
 
     template <typename T> void process (T);
 };

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -2,47 +2,39 @@
 
 #include "node.hh"
 #include "local_io.hh"
-#include "../network/asyncnode.hh"
-#include "../messages/blockinfo.hh"
-#include "../messages/fileinfo.hh"
-#include "../messages/keyrequest.hh"
-#include "../messages/filerequest.hh"
+#include "../messages/block.hh"
+#include "../messages/file.hh"
 #include "../messages/filedescription.hh"
-#include "../messages/filelist.hh"
-#include "../messages/filedel.hh"
-#include "../messages/blockdel.hh"
-#include "../messages/fileexist.hh"
+#include "../messages/list_files.hh"
 #include "../fs/directory.hh"
 #include "../common/histogram.hh"
 
 #include <string>
-#include <boost/asio.hpp>
 
 namespace eclipse {
 
 using vec_str = std::vector<std::string>;
 typedef std::function<void(std::string, std::string)> req_func;
 
-class PeerDFS: public Node, public AsyncNode {
+class PeerDFS: public Node {
   public:
     PeerDFS (network::Network*);
     ~PeerDFS ();
 
-    void on_read (messages::Message*, int) override;
-    void on_connect () override;
-    void on_disconnect(int) override;
+    void insert_key (uint32_t, std::string, std::string);
+    void request_key (std::string, int);
 
     virtual void insert (uint32_t, std::string, std::string);
     virtual void request (uint32_t, std::string, req_func);
 
     void close ();
-    bool insert_block (messages::BlockInfo*);
-    bool insert_file (messages::FileInfo*);
-    bool delete_block (messages::BlockDel*);
-    bool delete_file (messages::FileDel*);
-    bool list (messages::FileList*);
+    bool insert_block (messages::Block*);
+    bool insert_file (messages::File*);
+    bool delete_block (messages::Block*);
+    bool delete_file (std::string);
+    bool list (messages::List_files*);
     bool format ();
-    FileDescription request_file (messages::FileRequest*);
+    FileDescription request_file (std::string);
     bool file_exist (std::string);
 
   protected:
@@ -50,8 +42,6 @@ class PeerDFS: public Node, public AsyncNode {
     Local_io local_io;
     std::unique_ptr<Histogram> boundaries;
     std::map<std::string, req_func> requested_blocks;
-
-    template <typename T> void process (T);
 };
 
 }

--- a/src/nodes/remotedfs.cc
+++ b/src/nodes/remotedfs.cc
@@ -7,7 +7,9 @@ using namespace eclipse;
 namespace ph = std::placeholders;
 
 // Constructor {{{
-RemoteDFS::RemoteDFS () : Router() {
+RemoteDFS::RemoteDFS (PeerDFS* p, network::Network* net) : Router(net) {
+  peer_dfs = p;
+
   using namespace std::placeholders;
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -21,15 +23,6 @@ RemoteDFS::RemoteDFS () : Router() {
   rt.insert({"FileDel", bind(&RemoteDFS::delete_file, this, _1, _2)});
   rt.insert({"FormatRequest", bind(&RemoteDFS::request_format, this, _1, _2)});
   rt.insert({"FileExist", bind(&RemoteDFS::file_exist, this, _1, _2)});
-}
-// }}}
-// establish {{{
-bool RemoteDFS::establish () {
-  peer  = make_unique<PeerDFS> ();
-  peer_dfs = dynamic_cast<PeerDFS*> (peer.get());
-  peer_dfs->establish();
-  Router::establish();
-  return true;
 }
 // }}}
 // BlockInfo {{{

--- a/src/nodes/remotedfs.hh
+++ b/src/nodes/remotedfs.hh
@@ -10,10 +10,9 @@ using boost::asio::ip::tcp;
 
 class RemoteDFS: public Router {
   public:
-    RemoteDFS ();
+    RemoteDFS (PeerDFS*, network::Network*);
     ~RemoteDFS () = default;
 
-    virtual bool establish ();
     void insert_block (messages::Message*, int);
     void insert_file (messages::Message*, int);
     void request_file (messages::Message*, int);

--- a/src/nodes/router.cc
+++ b/src/nodes/router.cc
@@ -1,32 +1,18 @@
 #include "router.hh"
-#include "../common/dl_loader.hh"
-#include "../network/asyncnetwork.hh"
-#include "../network/server.hh"
 #include "../messages/factory.hh"
-#include "../messages/boost_impl.hh"
-
-#include <string>
-#include <sstream>
 
 using namespace eclipse;
 using namespace eclipse::messages;
-using namespace eclipse::network;
 using namespace std;
 
 namespace eclipse {
 // Constructor {{{
-Router::Router() : Node () {
-  port = context.settings.get<int>("network.ports.client");
-  network = new AsyncNetwork<Server> (this, port);
+Router::Router(network::Network* net) : Node () {
+  network = net;
+  net->attach(this);
 }
 
 Router::~Router() { }
-// }}}
-// establish {{{
-bool Router::establish () {
-  network->establish();
-  return true;
-}
 // }}}
 // on_read {{{
 void Router::on_read (Message* m, int n_channel) {

--- a/src/nodes/router.cc
+++ b/src/nodes/router.cc
@@ -1,23 +1,33 @@
 #include "router.hh"
+#include "../messages/executable.hh"
 #include "../messages/factory.hh"
 
 using namespace eclipse;
 using namespace eclipse::messages;
 using namespace std;
+namespace ph = std::placeholders;
 
 namespace eclipse {
 // Constructor {{{
-Router::Router(network::Network* net) : Node () {
+Router::Router(network::Network* net, PeerDFS* p) : Node () {
   network = net;
   net->attach(this);
+  peer = p;
 }
 
 Router::~Router() { }
 // }}}
 // on_read {{{
 void Router::on_read (Message* m, int n_channel) {
-  string type = m->get_type();
-  routing_table[type](m, n_channel);
+  if(dynamic_cast<Executable<PeerDFS>*>(m)) {
+    on_read_peerdfs(m, n_channel);
+  }
+}
+// }}}
+// on_read_peerdfs {{{
+void Router::on_read_peerdfs (Message* m, int n_channel) {
+  auto ex = dynamic_cast<Executable<PeerDFS>*>(m);
+  ex->exec(peer, std::bind(&Router::async_reply, this, ph::_1, n_channel));
 }
 // }}}
 // on_disconnect {{{
@@ -26,7 +36,12 @@ void Router::on_disconnect (int id) {
 // }}}
 // on_connect() {{{
 void Router::on_connect () {
-  logger->info("Client connected to executor #%d", id);
+  INFO("Client connected to executor #%d", id);
+}
+// }}}
+// async_reply {{{
+void Router::async_reply (messages::Message* m, int n_channel) {
+  network->send(n_channel, m);
 }
 // }}}
 } /* eclipse  */

--- a/src/nodes/router.cc
+++ b/src/nodes/router.cc
@@ -9,7 +9,7 @@ namespace ph = std::placeholders;
 
 namespace eclipse {
 // Constructor {{{
-Router::Router(network::Network* net, PeerDFS* p) : Node () {
+Router::Router(network::Network* net, FS* p) : Node () {
   network = net;
   net->attach(this);
   peer = p;
@@ -19,14 +19,14 @@ Router::~Router() { }
 // }}}
 // on_read {{{
 void Router::on_read (Message* m, int n_channel) {
-  if(dynamic_cast<Executable<PeerDFS>*>(m)) {
+  if(dynamic_cast<Executable<FS>*>(m)) {
     on_read_peerdfs(m, n_channel);
   }
 }
 // }}}
 // on_read_peerdfs {{{
 void Router::on_read_peerdfs (Message* m, int n_channel) {
-  auto ex = dynamic_cast<Executable<PeerDFS>*>(m);
+  auto ex = dynamic_cast<Executable<FS>*>(m);
   ex->exec(peer, std::bind(&Router::async_reply, this, ph::_1, n_channel));
 }
 // }}}

--- a/src/nodes/router.hh
+++ b/src/nodes/router.hh
@@ -1,22 +1,16 @@
 #pragma once
 #include "../nodes/node.hh"
 #include "../messages/boost_impl.hh"
-#include "../network/asyncnetwork.hh"
-#include "../network/server.hh"
 #include <functional>
 
 namespace eclipse {
-
-using boost::system::error_code;
-using boost::asio::ip::tcp;
 using namespace eclipse::network;
 
 class Router: public Node, public AsyncNode {
   public:
-    Router ();
+    Router (network::Network*);
     ~Router ();
 
-    bool establish() override; 
     void on_connect() override;
     void on_disconnect(int) override;
     void on_read(messages::Message*, int) override;

--- a/src/nodes/router.hh
+++ b/src/nodes/router.hh
@@ -5,7 +5,6 @@
 #include <functional>
 
 namespace eclipse {
-using namespace eclipse::network;
 
 class Router: public Node, public AsyncNode {
   public:
@@ -20,7 +19,7 @@ class Router: public Node, public AsyncNode {
 
   protected:
     FS* peer;
-    Network* network;
+    network::Network* network;
 };
 
 } /* eclipse  */ 

--- a/src/nodes/router.hh
+++ b/src/nodes/router.hh
@@ -1,5 +1,5 @@
 #pragma once
-#include "../nodes/node.hh"
+#include "../nodes/peerdfs.hh"
 #include "../messages/boost_impl.hh"
 #include <functional>
 
@@ -8,17 +8,18 @@ using namespace eclipse::network;
 
 class Router: public Node, public AsyncNode {
   public:
-    Router (network::Network*);
+    Router (network::Network*, PeerDFS*);
     ~Router ();
 
     void on_connect() override;
     void on_disconnect(int) override;
     void on_read(messages::Message*, int) override;
+    void on_read_peerdfs(messages::Message*, int);
+    void async_reply(messages::Message*, int);
 
   protected:
-    std::map<std::string, std::function<void(messages::Message*, int)>> routing_table;
-    std::unique_ptr<Node> peer;
-    int port;
+    PeerDFS* peer;
+    Network* network;
 };
 
 } /* eclipse  */ 

--- a/src/nodes/router.hh
+++ b/src/nodes/router.hh
@@ -1,5 +1,6 @@
 #pragma once
-#include "../nodes/peerdfs.hh"
+#include "../nodes/node.hh"
+#include "../nodes/fs.hh"
 #include "../messages/boost_impl.hh"
 #include <functional>
 
@@ -8,7 +9,7 @@ using namespace eclipse::network;
 
 class Router: public Node, public AsyncNode {
   public:
-    Router (network::Network*, PeerDFS*);
+    Router (network::Network*, FS*);
     ~Router ();
 
     void on_connect() override;
@@ -18,7 +19,7 @@ class Router: public Node, public AsyncNode {
     void async_reply(messages::Message*, int);
 
   protected:
-    PeerDFS* peer;
+    FS* peer;
     Network* network;
 };
 

--- a/src/targets/node_main.cc
+++ b/src/targets/node_main.cc
@@ -13,10 +13,11 @@ int main (int argc, char ** argv) {
 
   network::Network* internal_net = new network::AsyncNetwork<P2P>(in_port);
   PeerDFS peer (internal_net);
+  Router router (internal_net, &peer);
   internal_net->establish();
 
   network::Network* external_net = new network::AsyncNetwork<Server>(ex_port);
-  RemoteDFS remote (&peer, external_net);
+  Router router2 (external_net, &peer);
   external_net->establish();
 
   context.join();

--- a/src/targets/node_main.cc
+++ b/src/targets/node_main.cc
@@ -1,12 +1,27 @@
 #include <nodes/remotedfs.hh>
 #include <common/context.hh>
+#include <network/p2p.hh>
+#include <network/server.hh>
+#include <network/asyncnetwork.hh>
 #include <string>
 
 using namespace eclipse;
 
 int main (int argc, char ** argv) {
-  RemoteDFS nl;
-  nl.establish();
+  int in_port = context.settings.get<int>("network.ports.internal");
+  int ex_port = context.settings.get<int>("network.ports.client");
 
-  return context.join();
+  network::Network* internal_net = new network::AsyncNetwork<P2P>(in_port);
+  PeerDFS peer (internal_net);
+  internal_net->establish();
+
+  network::Network* external_net = new network::AsyncNetwork<Server>(ex_port);
+  RemoteDFS remote (&peer, external_net);
+  external_net->establish();
+
+  context.join();
+  delete internal_net;
+  delete external_net;
+
+  return EXIT_SUCCESS;
 }

--- a/src/targets/node_main.cc
+++ b/src/targets/node_main.cc
@@ -1,4 +1,3 @@
-//#include <nodes/remotedfs.hh>
 #include <common/context.hh>
 #include <network/p2p.hh>
 #include <network/server.hh>
@@ -9,18 +8,19 @@
 #include <string>
 
 using namespace eclipse;
+using namespace eclipse::network;
 
 int main (int argc, char ** argv) {
   int in_port = context.settings.get<int>("network.ports.internal");
   int ex_port = context.settings.get<int>("network.ports.client");
 
-  network::Network* internal_net = new network::AsyncNetwork<P2P>(in_port);
+  Network* internal_net = new AsyncNetwork<P2P>(in_port);
   DIO dio (internal_net);
   DFS dfs (&dio);
   Router router (internal_net, &dfs);
   internal_net->establish();
 
-  network::Network* external_net = new network::AsyncNetwork<Server>(ex_port);
+  Network* external_net = new AsyncNetwork<Server>(ex_port);
   Router router2 (external_net, &dfs);
   external_net->establish();
 

--- a/src/targets/node_main.cc
+++ b/src/targets/node_main.cc
@@ -1,8 +1,11 @@
-#include <nodes/remotedfs.hh>
+//#include <nodes/remotedfs.hh>
 #include <common/context.hh>
 #include <network/p2p.hh>
 #include <network/server.hh>
 #include <network/asyncnetwork.hh>
+#include <nodes/router.hh>
+#include <nodes/dio.hh>
+#include <nodes/dfs.hh>
 #include <string>
 
 using namespace eclipse;
@@ -12,12 +15,13 @@ int main (int argc, char ** argv) {
   int ex_port = context.settings.get<int>("network.ports.client");
 
   network::Network* internal_net = new network::AsyncNetwork<P2P>(in_port);
-  PeerDFS peer (internal_net);
-  Router router (internal_net, &peer);
+  DIO dio (internal_net);
+  DFS dfs (&dio);
+  Router router (internal_net, &dfs);
   internal_net->establish();
 
   network::Network* external_net = new network::AsyncNetwork<Server>(ex_port);
-  Router router2 (external_net, &peer);
+  Router router2 (external_net, &dfs);
   external_net->establish();
 
   context.join();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,7 @@ nodes_SOURCES   = tests/nodes.cc \
                   src/nodes/peerdfs.cc \
                   src/nodes/remotedfs.cc \
                   src/nodes/router.cc \
+                  src/nodes/local_io.cc \
                   src/fs/directory.cc \
                   src/nodes/node.cc 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,15 +23,14 @@ units_SOURCES      = $(messages_files) \
                      src/network/channel.cc \
                      src/network/asyncchannel.cc \
                      src/network/p2p.cc \
-										 src/network/acceptor.cc \
-										 src/network/connector.cc \
+                     src/network/acceptor.cc \
+                     src/network/connector.cc \
                      src/nodes/machine.cc \
                      src/nodes/node.cc 
 
 nodes_LDADD     = $(LDADD_T)
 nodes_CPPFLAGS  = $(AM_CPPFLAGS_T)
 nodes_SOURCES   = tests/nodes.cc \
-                  $(messages_files) \
                   src/network/channel.cc \
                   src/network/asyncchannel.cc \
                   src/network/p2p.cc \
@@ -39,12 +38,13 @@ nodes_SOURCES   = tests/nodes.cc \
                   src/network/acceptor.cc \
                   src/network/connector.cc \
                   src/nodes/machine.cc \
-                  src/nodes/peerdfs.cc \
-                  src/nodes/remotedfs.cc \
-                  src/nodes/router.cc \
+                  src/nodes/dfs.cc \
+                  src/nodes/dio.cc \
                   src/nodes/local_io.cc \
+                  src/nodes/router.cc \
                   src/fs/directory.cc \
-                  src/nodes/node.cc 
+                  src/nodes/node.cc \
+                  $(messages_files)
 
 metadata_LDADD     = $(LDADD_T)
 metadata_CPPFLAGS  = $(AM_CPPFLAGS_T)

--- a/tests/metadata_test.cc
+++ b/tests/metadata_test.cc
@@ -13,8 +13,8 @@ int main() {
 
   // Basic metadata io example
   dir.init_db();
-  FileInfo file_info;
-  BlockInfo block_info;
+  File file_info;
+  Block block_info;
 
   file_info.file_name = "test.txt";
   file_info.file_hash_key = 1;

--- a/tests/nodes.cc
+++ b/tests/nodes.cc
@@ -1,15 +1,32 @@
-#include <nodes/remotedfs.hh>
 #include <common/context.hh>
+#include <network/p2p.hh>
+#include <network/server.hh>
+#include <network/asyncnetwork.hh>
+#include <nodes/router.hh>
+#include <nodes/dio.hh>
+#include <nodes/dfs.hh>
 #include <string>
 
 using namespace eclipse;
+using namespace eclipse::network;
 
 int main (int argc, char ** argv) {
+  int in_port = context.settings.get<int>("network.ports.internal");
+  int ex_port = context.settings.get<int>("network.ports.client");
 
-  std::string input = argv[1];
+  Network* internal_net = new AsyncNetwork<P2P>(in_port);
+  DIO dio (internal_net);
+  DFS dfs (&dio);
+  Router router (internal_net, &dfs);
+  internal_net->establish();
 
-  RemoteDFS nl;
-  nl.establish();
+  Network* external_net = new AsyncNetwork<Server>(ex_port);
+  Router router2 (external_net, &dfs);
+  external_net->establish();
 
-  return context.join();
+  context.join();
+  delete internal_net;
+  delete external_net;
+
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Before we merge this PR to master, get familiar with the changes I introduced.
## Reason of refactor
1. Code duplication 
2. Race condition problems
3. God class (PeerDFS) and dependency hell.

## Changes 
1. Splited PeerDFS into DIO(Distributed IO), DFS, and Local_IO
2. Removed RemoteDFS and move message behavior into each of the messages.
3. Added few interfaces to remove dependency.
4. Split messages into Executable messages (messages which have action such as FileList, FileDel) and plain messages (such as File, Block, and List_Files).

Here is a picture of a diagram of the new architecture:

![eclipsedfs object diagram](https://cloud.githubusercontent.com/assets/939798/15049574/e3ca2aee-1329-11e6-83c1-785bb42469f0.png)

You can find the diagram in this [URL](https://drive.google.com/file/d/0B0hn91behy9cMW1jS1l6ZkVmMDQ/view?usp=sharing) 
