### PR TITLE
Refactor: remove dependencies

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/network/connector.cc \
 											 src/nodes/machine.cc \
 											 src/nodes/peerdfs.cc \
+											 src/nodes/local_io.cc \
 											 src/nodes/remotedfs.cc \
 											 src/nodes/router.cc \
 											 src/fs/directory.cc \

--- a/src/common/context.hh
+++ b/src/common/context.hh
@@ -33,3 +33,8 @@ class Context {
 };
 
 extern Context& context;
+
+#define ERROR(X, ...) context.logger->error(X, ##__VA_ARGS__ )
+#define WARN(X, ...) context.logger->warn(X, ##__VA_ARGS__)
+#define INFO(X, ...) context.logger->info(X, ##__VA_ARGS__)
+#define DEBUG(X, ...) context.logger->debug(X, ##__VA_ARGS__)

--- a/src/common/histogram.cc
+++ b/src/common/histogram.cc
@@ -132,7 +132,7 @@ void Histogram::set_count (int index, double count)
 void Histogram::updateboundary()   // update the boundary according to the query counts
 {
     // sum up the count of all bin and divide it by number of servers(query per server)
-    double qps = 0.0;
+    double qps = 0.0;              // query per server
     double temp = 0.0;
     double stmeter = 0.0;
     int j = 0;

--- a/src/common/logger.cc
+++ b/src/common/logger.cc
@@ -88,9 +88,9 @@ void Logger::warn (const char* fmt, ...) {
 void Logger::error (const char* fmt, ...) { 
   va_list ap;
   char msg [256];
-
-  strncpy(msg, fmt, 256 );
-  strncat(msg," [ERR:%m]", 256);
+  strncpy(msg,"ERROR ", 256);
+  strncat(msg, fmt, 256);
+  strncat(msg," ERRSTR:%m", 256);
   va_start(ap, fmt);
   log(LOG_ERR, msg, ap);
   va_end(ap);
@@ -121,8 +121,9 @@ void Logger::error_if (bool cmp, const char* fmt, ...) {
     va_list ap;
     char msg [256];
 
-    strncpy(msg, fmt, 256 );
-    strncat(msg," [ERR:%m]", 256);
+    strncpy(msg,"ERROR ", 256);
+    strncat(msg, fmt, 256 );
+    strncat(msg," ERRSTR:%m", 256);
     va_start(ap, fmt);
     log(LOG_ERR, msg, ap);
     va_end(ap);

--- a/src/fs/directory.cc
+++ b/src/fs/directory.cc
@@ -131,7 +131,9 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      context.logger->error("SQL error: %s\n", zErrMsg);
+      if (rc != SQLITE_ERROR)
+        context.logger->error("SQL error: %s\n", zErrMsg);
+
       sqlite3_free(zErrMsg);
     }
     else
@@ -157,7 +159,9 @@ namespace eclipse{
     rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
     if(rc != SQLITE_OK)
     {
-      context.logger->error("SQL error: %s\n", zErrMsg);
+      if (rc != SQLITE_ERROR)
+        context.logger->error("SQL error: %s\n", zErrMsg);
+
       sqlite3_free(zErrMsg);
     }
     else

--- a/src/network/asyncchannel.cc
+++ b/src/network/asyncchannel.cc
@@ -46,38 +46,34 @@ void AsyncChannel::do_write_impl (string* to_write) {
 }
 // }}}
 // on_write {{{
-void AsyncChannel::on_write (const boost::system::error_code& ec, 
-    size_t s, string* str) {
+void AsyncChannel::on_write (const error_code& ec, size_t s, string* str) {
   delete str;
   if (ec) {
-    logger->info ("Message could not reach err=%s", 
-        ec.message().c_str());
-
+    INFO("Message could not reach err=%s", ec.message().c_str());
     do_write_impl(str);
   }
 }
 // }}}
 // do_read {{{
 void AsyncChannel::do_read () {
-  logger->info("Connection established, starting to read");
+  DEBUG("Connection established, starting to read");
   spawn(iosvc, bind(&AsyncChannel::read_coroutine, this, _1));
 }
 // }}}
 // read_coroutine {{{
 void AsyncChannel::read_coroutine (yield_context yield) {
-  boost::asio::streambuf body; 
-  boost::system::error_code ec;
-  char header [header_size + 1]; 
-  header[16] = '\0';
-
   try {
+    boost::asio::streambuf body; 
+    boost::system::error_code ec;
+    char header [header_size + 1] = {'\0'}; 
+    header[16] = '\0';
+
     while (true) {
       size_t l = async_read (*receiver, buffer(header, header_size), yield[ec]);
-      if (l != (size_t)header_size or ec) throw 1;
+      if (l != (size_t)header_size or ec) throw ec;
 
       size_t size = atoi(header);
       l = read (*receiver, body.prepare(size));
-      //if (ec) throw 1;
 
       body.commit (l);
       string str ((istreambuf_iterator<char>(&body)), 
@@ -90,14 +86,18 @@ void AsyncChannel::read_coroutine (yield_context yield) {
       delete msg;
       msg=nullptr;
     }
-  } catch (...) {
+  } catch (boost::system::error_code& ec) {
     if (ec == boost::asio::error::eof)
-      logger->info ("AsyncChannel: Closing server socket to client");
+      INFO("AsyncChannel: Closing server socket to client");
+
     else
-      logger->info ("AsyncChannel: Message arrived error=%s", 
+      ERROR("AsyncChannel: Message arrived error=%s", 
           ec.message().c_str());
 
-      node->on_disconnect(nullptr, id);
+  } catch (std::exception& e) {
+      INFO("AsyncChannel: Exception raised");
   }
+
+  node->on_disconnect(nullptr, id);
 }
 // }}}

--- a/src/network/asyncnetwork.hh
+++ b/src/network/asyncnetwork.hh
@@ -17,17 +17,20 @@ using boost::asio::ip::tcp;
 template<typename TYPE>
 class AsyncNetwork: public Network, public NetObserver {
   public:
-    AsyncNetwork(AsyncNode*, int);
+    AsyncNetwork(int);
     ~AsyncNetwork ();
 
     bool establish() override;
     bool close () override;
     size_t size () override;
     bool send(int, messages::Message*) override;
+    void attach(AsyncNode*) override;
+
     void on_accept(tcp::socket*) override;
     void on_connect(tcp::socket*) override;
     void on_disconnect(tcp::socket*, int) override;
     void on_read(messages::Message*, int) override;
+
 
   private:
     int id_of(tcp::socket*);
@@ -48,8 +51,7 @@ class AsyncNetwork: public Network, public NetObserver {
 };
 // Constructor {{{
 template<typename TYPE>
-AsyncNetwork<TYPE>::AsyncNetwork (AsyncNode* n, int port):
-  node(n),
+AsyncNetwork<TYPE>::AsyncNetwork (int port):
   nodes(context.settings.get<vec_str> ("network.nodes")),
   acceptor(port, this),
   connector(port, this),
@@ -193,6 +195,12 @@ void AsyncNetwork<TYPE>::start_reading () {
 template <typename TYPE>
 void AsyncNetwork<TYPE>::on_read (messages::Message* m , int id) {
   node->on_read(m, id);
+}
+// }}}
+// attach {{{
+template <typename TYPE>
+void AsyncNetwork<TYPE>::attach (AsyncNode* node_) {
+  node = node_;
 }
 // }}}
 }

--- a/src/network/asyncnetwork.hh
+++ b/src/network/asyncnetwork.hh
@@ -89,9 +89,8 @@ size_t AsyncNetwork<TYPE>::size () {
 // send {{{
 template<typename TYPE>
 bool AsyncNetwork<TYPE>::send (int i, messages::Message* m) {
-  acceptor_mutex.lock(); 
+  std::lock_guard<std::mutex> lck (acceptor_mutex); 
   channels[i]->do_write(m);
-  acceptor_mutex.unlock(); 
   return true;
 }
 // }}}
@@ -99,11 +98,10 @@ bool AsyncNetwork<TYPE>::send (int i, messages::Message* m) {
 template<typename TYPE>
 void AsyncNetwork<TYPE>::on_accept (tcp::socket* sock) {
   if (not TYPE::is_multiple()) {
-    acceptor_mutex.lock(); 
+    std::lock_guard<std::mutex> lck (acceptor_mutex); 
     channels.emplace (accepted_size.load(), std::make_unique<TYPE> (sock, sock, this, accepted_size.load()));
     accepted_size++;
     channels[accepted_size.load() - 1]->do_read();
-    acceptor_mutex.unlock(); 
 
   } else {
     auto i = id_of (sock);
@@ -142,9 +140,8 @@ void AsyncNetwork<TYPE>::on_disconnect (tcp::socket* sock, int id) {
 
   accepted_size--;
 
-  acceptor_mutex.lock(); 
+  std::lock_guard<std::mutex> lck (acceptor_mutex); 
   channels.erase(id);
-  acceptor_mutex.unlock(); 
 }
 // }}}
 // completed_network {{{

--- a/src/network/network.hh
+++ b/src/network/network.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "../messages/message.hh"
+#include "asyncnode.hh"
 
 namespace eclipse {
 namespace network {
@@ -12,6 +13,7 @@ class Network {
     virtual bool close () = 0;
     virtual size_t size () = 0;
     virtual bool send(int, messages::Message*) = 0;
+    virtual void attach (AsyncNode*) = 0;
 };
 
 }

--- a/src/nodes/local_io.cc
+++ b/src/nodes/local_io.cc
@@ -7,9 +7,11 @@
 using namespace eclipse;
 using namespace std;
 
+// constructors {{{
 Local_io::Local_io() {
   disk_path = context.settings.get<string>("path.scratch");
 }
+//  }}}
 // write {{{
 void Local_io::write (std::string name, std::string v) {
   string file_path = disk_path + string("/") + name;

--- a/src/nodes/local_io.cc
+++ b/src/nodes/local_io.cc
@@ -1,0 +1,55 @@
+#include "local_io.hh"
+#include "../common/context.hh"
+#include <cstdio>
+#include <dirent.h>
+#include <fstream>
+
+using namespace eclipse;
+using namespace std;
+
+Local_io::Local_io() {
+  disk_path = context.settings.get<string>("path.scratch");
+}
+// write {{{
+void Local_io::write (std::string name, std::string v) {
+  string file_path = disk_path + string("/") + name;
+  ofstream file (file_path);
+  file << v;
+  file.close();
+}
+// }}}
+// read {{{
+std::string Local_io::read (string name) {
+  ifstream in (disk_path + string("/") + name);
+  string value ((std::istreambuf_iterator<char>(in)),
+      std::istreambuf_iterator<char>());
+
+  in.close();
+  return value;
+}
+// }}}
+// format {{{
+bool Local_io::format () {
+  string fs_path = context.settings.get<string>("path.scratch");
+  string md_path = context.settings.get<string>("path.metadata");
+
+  DIR *theFolder = opendir(fs_path.c_str());
+  struct dirent *next_file;
+  char filepath[256] = {0};
+
+  while ( (next_file = readdir(theFolder)) != NULL ) {
+    sprintf(filepath, "%s/%s", fs_path.c_str(), next_file->d_name);
+    remove(filepath);
+  }
+  closedir(theFolder);
+
+  ::remove((md_path + "/metadata.db").c_str());
+  return true;
+}
+// }}}
+// remove {{{
+void Local_io::remove (std::string k) {
+  string file_path = disk_path + string("/") + k;
+  ::remove(file_path.c_str());
+}
+// }}}

--- a/src/nodes/local_io.hh
+++ b/src/nodes/local_io.hh
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+
+namespace eclipse {
+
+class Local_io {
+  public:
+    void write (std::string, std::string);
+    std::string read (std::string);
+    void remove (std::string);
+    bool format ();
+
+    Local_io();
+   
+  private:
+    std::string disk_path;
+};
+
+}

--- a/src/nodes/node.hh
+++ b/src/nodes/node.hh
@@ -17,7 +17,6 @@ class Node: public Machine {
     ~Node();
 
     std::string get_ip () const override;
-    virtual bool establish() = 0;
 
   protected:
     network::Network* network;

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "node.hh"
+#include "local_io.hh"
 #include "../network/asyncnode.hh"
 #include "../messages/blockinfo.hh"
 #include "../messages/fileinfo.hh"
@@ -35,7 +36,6 @@ class PeerDFS: public Node, public AsyncNode {
     virtual void insert (uint32_t, std::string, std::string);
     virtual void request (uint32_t, std::string, req_func);
 
-    void Delete (std::string);
     void close ();
     bool insert_block (messages::BlockInfo*);
     bool insert_file (messages::FileInfo*);
@@ -48,6 +48,7 @@ class PeerDFS: public Node, public AsyncNode {
 
   protected:
     Directory directory;
+    Local_io local_io;
     std::unique_ptr<Histogram> boundaries;
     std::map<std::string, req_func> requested_blocks;
     bool connected = false;

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -25,10 +25,9 @@ typedef std::function<void(std::string, std::string)> req_func;
 
 class PeerDFS: public Node, public AsyncNode {
   public:
-    PeerDFS ();
+    PeerDFS (network::Network*);
     ~PeerDFS ();
 
-    bool establish () override;
     void on_read (messages::Message*, int) override;
     void on_connect () override;
     void on_disconnect(int) override;
@@ -51,9 +50,6 @@ class PeerDFS: public Node, public AsyncNode {
     Local_io local_io;
     std::unique_ptr<Histogram> boundaries;
     std::map<std::string, req_func> requested_blocks;
-    bool connected = false;
-    int size;
-    std::string disk_path;
 
     template <typename T> void process (T);
 };

--- a/src/nodes/remotedfs.cc
+++ b/src/nodes/remotedfs.cc
@@ -7,7 +7,9 @@ using namespace eclipse;
 namespace ph = std::placeholders;
 
 // Constructor {{{
-RemoteDFS::RemoteDFS () : Router() {
+RemoteDFS::RemoteDFS (PeerDFS* p, network::Network* net) : Router(net) {
+  peer_dfs = p;
+
   using namespace std::placeholders;
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -21,15 +23,6 @@ RemoteDFS::RemoteDFS () : Router() {
   rt.insert({"FileDel", bind(&RemoteDFS::delete_file, this, _1, _2)});
   rt.insert({"FormatRequest", bind(&RemoteDFS::request_format, this, _1, _2)});
   rt.insert({"FileExist", bind(&RemoteDFS::file_exist, this, _1, _2)});
-}
-// }}}
-// establish {{{
-bool RemoteDFS::establish () {
-  peer  = make_unique<PeerDFS> ();
-  peer_dfs = dynamic_cast<PeerDFS*> (peer.get());
-  peer_dfs->establish();
-  Router::establish();
-  return true;
 }
 // }}}
 // BlockInfo {{{

--- a/src/nodes/remotedfs.hh
+++ b/src/nodes/remotedfs.hh
@@ -10,10 +10,9 @@ using boost::asio::ip::tcp;
 
 class RemoteDFS: public Router {
   public:
-    RemoteDFS ();
+    RemoteDFS (PeerDFS*, network::Network*);
     ~RemoteDFS () = default;
 
-    virtual bool establish ();
     void insert_block (messages::Message*, int);
     void insert_file (messages::Message*, int);
     void request_file (messages::Message*, int);

--- a/src/nodes/router.cc
+++ b/src/nodes/router.cc
@@ -1,32 +1,18 @@
 #include "router.hh"
-#include "../common/dl_loader.hh"
-#include "../network/asyncnetwork.hh"
-#include "../network/server.hh"
 #include "../messages/factory.hh"
-#include "../messages/boost_impl.hh"
-
-#include <string>
-#include <sstream>
 
 using namespace eclipse;
 using namespace eclipse::messages;
-using namespace eclipse::network;
 using namespace std;
 
 namespace eclipse {
 // Constructor {{{
-Router::Router() : Node () {
-  port = context.settings.get<int>("network.ports.client");
-  network = new AsyncNetwork<Server> (this, port);
+Router::Router(network::Network* net) : Node () {
+  network = net;
+  net->attach(this);
 }
 
 Router::~Router() { }
-// }}}
-// establish {{{
-bool Router::establish () {
-  network->establish();
-  return true;
-}
 // }}}
 // on_read {{{
 void Router::on_read (Message* m, int n_channel) {

--- a/src/nodes/router.hh
+++ b/src/nodes/router.hh
@@ -1,22 +1,16 @@
 #pragma once
 #include "../nodes/node.hh"
 #include "../messages/boost_impl.hh"
-#include "../network/asyncnetwork.hh"
-#include "../network/server.hh"
 #include <functional>
 
 namespace eclipse {
-
-using boost::system::error_code;
-using boost::asio::ip::tcp;
 using namespace eclipse::network;
 
 class Router: public Node, public AsyncNode {
   public:
-    Router ();
+    Router (network::Network*);
     ~Router ();
 
-    bool establish() override; 
     void on_connect() override;
     void on_disconnect(int) override;
     void on_read(messages::Message*, int) override;

--- a/src/targets/node_main.cc
+++ b/src/targets/node_main.cc
@@ -1,12 +1,27 @@
 #include <nodes/remotedfs.hh>
 #include <common/context.hh>
+#include <network/p2p.hh>
+#include <network/server.hh>
+#include <network/asyncnetwork.hh>
 #include <string>
 
 using namespace eclipse;
 
 int main (int argc, char ** argv) {
-  RemoteDFS nl;
-  nl.establish();
+  int in_port = context.settings.get<int>("network.ports.internal");
+  int ex_port = context.settings.get<int>("network.ports.client");
 
-  return context.join();
+  network::Network* internal_net = new network::AsyncNetwork<P2P>(in_port);
+  PeerDFS peer (internal_net);
+  internal_net->establish();
+
+  network::Network* external_net = new network::AsyncNetwork<Server>(ex_port);
+  RemoteDFS remote (&peer, external_net);
+  external_net->establish();
+
+  context.join();
+  delete internal_net;
+  delete external_net;
+
+  return EXIT_SUCCESS;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,7 @@ nodes_SOURCES   = tests/nodes.cc \
                   src/nodes/peerdfs.cc \
                   src/nodes/remotedfs.cc \
                   src/nodes/router.cc \
+                  src/nodes/local_io.cc \
                   src/fs/directory.cc \
                   src/nodes/node.cc 
 


### PR DESCRIPTION
Summary of changes:
1. PeerDFS does not control the life-span of the network class.
2. Removed annoying bug for fake message when we start eclipsedfs from directory class 
3. Added class local_io and moved (write, read, format, and remove) from peerdfs to that class.