### PR TITLE
Configure script now checks boost version and sqlite3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "doc/manual"]
 	path = doc/manual
 	url = git@github.com:DICL/EclipseDFS.wiki.git
-[submodule "gh-pages"]
-	path = doc/html
-	url = git@github.com:DICL/EclipseDFS
-	branch = gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ after_success: |
         cd ..
         git config --global user.email "Travis"
         git config --global user.name  "Travis"
+        git submodule add git@github.com:DICL/EclipseDFS ./doc/html
         git submodule update --init -- ./doc/html
         cd doc/html
         git checkout gh-pages

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 include tests/Makefile.am
 
-AM_CPPFLAGS      = -I@srcdir@/src/common -I@srcdir@/src -include ./config.h
-AM_CXXFLAGS      = -Wall -std=c++14 -ggdb3 
+AM_CPPFLAGS      = -I@srcdir@/src/common -I@srcdir@/src -include ./config.h $(BOOST_CPPFLAGS)
+AM_CXXFLAGS      = $(CXXFLAGS) -Wall 
 
 bin_PROGRAMS     = eclipse_node dfs
 
@@ -35,11 +35,11 @@ libecfs_la_SOURCES  = src/common/hash.cc src/common/settings.cc \
 											src/common/context.cc src/common/dl_loader.cc \
 											src/common/context_singleton.cc
 
-libecfs_la_LDFLAGS  = -version-info 0:0:0 
+libecfs_la_LDFLAGS  = $(BOOST_LDFLAGS) -version-info 0:0:0 
 
 # Binaries ----
-AM_LDFLAGS          = -static
-LDADD               = libecfs.la -lboost_system -lboost_thread -lboost_serialization -lboost_system -lboost_coroutine -lboost_context
+AM_LDFLAGS          = -static $(BOOST_LDFLAGS)
+LDADD               = libecfs.la -lboost_system -lboost_serialization -lboost_coroutine -lboost_thread -lboost_context
 
 eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/network/channel.cc \
@@ -57,14 +57,10 @@ eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/nodes/node.cc \
 											 $(messages_files)
 
-eclipse_node_LDADD  = $(LDADD) -lsqlite3
-
 dfs_SOURCES         = src/fs/dfs.cc \
                       src/fs/directory.cc \
                       src/fs/main.cc \
 											$(messages_files)
-
-dfs_LDADD           = $(LDADD) -lsqlite3
 
 pkginclude_HEADERS  = src/common/ecfs.hh src/common/settings.hh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS  = -I m4
 include tests/Makefile.am
 
 AM_CPPFLAGS      = -I@srcdir@/src/common -I@srcdir@/src -include ./config.h $(BOOST_CPPFLAGS)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Once the system is running, you can interact with EclipseDFS with the following 
 COMPILING & INSTALLING
 =====================
 
+Compiling requirements
+----------------------
+ - C++14 support, this is: GCC >= 4.9, Clang >= 3.4, or ICC >= 16.0.
+ - Boost library >= 1.53.
+ - Sqlite3 library.
+ - GNU Autotools (Autoconf, Automake, Libtool).
+ - Unittest++ [optional].
+
 For single user installation for developers
 -------------------------------------------
 
@@ -37,7 +45,9 @@ For single user installation for developers
     $ cd EclipseDFS
     $ sh autogen.sh                                        # Generate configure script 
     $ cd ../tmp                                            # Go to building folder
-    $ sh ../EclipseDFS/configure --prefix=`pwd`/../sandbox    # Generate Makefile
+    $ sh ../EclipseDFS/configure --prefix=`pwd`/../sandbox # Check requirements and generate the Makefile
+
+    # If you get a boost error go the FAQ section of the README
 
     ### This last command will be needed whenever you want to recompile the source
     $ make [-j#] install                                   # Compile & install add -j flag to speed up
@@ -52,6 +62,18 @@ Now edit in your **~/.bashrc** or **~/.profile**:
 For the configuration refer to the manpage:
 
     $ man eclipsefs
+
+FAQ
+---
+
+- _Question_ : `configure` stops with errors related to boost library.
+- _Answer_ : It probably means that you do not have boost library installed in
+  the default location, in such case you should specify the boost library location.
+  ```
+  sh ../EclipseDFS/configure --prefix ~/sandbox --with-boost=/usr/local --with-boost-libdir=/usr/local/lib
+  ```
+  In this example we assume that the boost headers are in `/usr/local/include` while the library files
+  are inside `/usr/local/lib`.
 
 AUTHOR
 ======

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Eclipse], [00.18.04], [vicente.bolea@gmail.com], [], [dicl.unist.ac.kr])
+AC_INIT([EclipseDFS], [01.04.00], [vicente.bolea@gmail.com], [], [dicl.unist.ac.kr])
 AC_CONFIG_AUX_DIR([./.autotools_aux])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
@@ -13,39 +13,23 @@ AC_CONFIG_FILES([tests/eclipse_debug],    [chmod +x tests/eclipse_debug])
 AM_CONDITIONAL([DEFAULT_CXXFLAGS], [test -z "$CXXFLAGS"])
 AM_COND_IF([DEFAULT_CXXFLAGS], [CXXFLAGS='-g -O0 -march=native'])
 
-CXXFLAGS="$CXXFLAGS -std=c++14" #make sure the compiler support C++14
 AC_PROG_CXX
 AC_LANG([C++])
 AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
 
-# Argumeznts {{{
+# Arguments {{{
 AC_ARG_ENABLE([samples],
     AS_HELP_STRING([--disable-samples], [copy sample of eclipse.json]))
-
-default_fs="DHT"
-AC_ARG_WITH([fs],
-    [AS_HELP_STRING([--with-fs], [File system <DHT|HDFS> ])],
-    [fs="$withval"], [fs="$default_fs"]) 
-
-AC_ARG_WITH([boost],
-    [AS_HELP_STRING([--with-boost@<:@=PATH@:>@], [specify boost path])],
-    [boost_path="$withval"], [boost_path=no]) 
-
-    if test "$boost_path" != no ; then
-      CPPFLAGS="$CPPFLAGS -I $boost_path"
-    fi
 
 # Configure options: --enable-debug[=no].
 AC_ARG_ENABLE([debug],
   [AS_HELP_STRING([--enable-debug], [enable debug code (default is no)])],
     [debug="$withval"], [debug=no])
 
-AM_CONDITIONAL(FS_IS_DHT, [test "$fs" = DHT])
 AM_CONDITIONAL(COPY_SAMPLES, [test "$enable_samples" != no ])
 
 #}}}
 # Dependencies checkings {{{
-
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
 AC_TYPE_UINT16_T
@@ -54,16 +38,11 @@ AC_TYPE_UINT8_T
 AC_HEADER_STDC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h sys/socket.h sys/time.h unistd.h])
 AC_SEARCH_LIBS([pthread_create], [pthread])
+AC_SEARCH_LIBS([sqlite3_exec], [sqlite3])
 
-# Check for binaries
-AC_CHECK_PROG([have_ssh], [ssh], [yes], [no])
-AC_CHECK_PROG([have_scp], [scp], [yes], [no])
-AC_CHECK_PROG([have_astyle], [astyle], [yes], [no])
-
-have_ruby=no
+AX_BOOST_BASE([1.53.0], ,
+              [AC_MSG_ERROR([Needs BOOST])])
 have_unittest=no
-ECLIPSE_FIND_BOOST
-AX_PROG_RUBY_VERSION([2.1.0], [have_ruby=yes], [have_ruby=no])
 PKG_CHECK_EXISTS([UnitTest++], [have_unittest=yes], [have_unittest=no])
 
 #}}}
@@ -94,20 +73,16 @@ WARN([\
  C++ Compiler.....: $CXX $CXXFLAGS $CPPFLAGS
  LIBS.............: $LIBS
  Copy samples?....: ${enable_samples:-NO}
- File System?.....: $fs
 
  Dependencies
  ------------
  [Required]
- Boost path.......: ${boost_path:-DEFAULT}
- Have Boost?......: $have_boost
- Have Ruby?.......: $have_ruby
- Have ssh?........: $have_ssh
- Have scp?........: $have_scp
+ Have Boost?......: ${HAVE_BOOST-YES}
+ BOOST CPPFLAGS...: $BOOST_CPPFLAGS
+ BOOST LDFLAGS....: $BOOST_LDFLAGS
 
  [Optional]
  Have UnitTest++?.: $have_unittest
- Have astyle?.....: $have_astyle
  
  Next, type:
  AS_HELP_STRING([make @<:@-j<processors>@:>@], [Processors indicate how many threads you want to use])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,13 @@
-AC_INIT([EclipseDFS], [01.04.00], [vicente.bolea@gmail.com], [], [dicl.unist.ac.kr])
+AC_INIT([EclipseDFS], 
+    m4_esyscmd_s([git describe --tags | grep -o "[[:digit:]]\.[[:digit:]]\.[[:digit:]]"]), 
+    [vicente.bolea@gmail.com], 
+    [], [dicl.unist.ac.kr])
 AC_CONFIG_AUX_DIR([./.autotools_aux])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
 LT_INIT([dlopen])
 
-AC_CONFIG_MACRO_DIR([./m4/])
+#AC_CONFIG_MACRO_DIR([./m4/])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile ])
 AC_CONFIG_FILES([tests/nodes_executor],    [chmod +x tests/nodes_executor])

--- a/m4/AX_BOOST_BASE.m4
+++ b/m4/AX_BOOST_BASE.m4
@@ -1,0 +1,285 @@
+# ===========================================================================
+#       http://www.gnu.org/software/autoconf-archive/ax_boost_base.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_BASE([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+#
+# DESCRIPTION
+#
+#   Test for the Boost C++ libraries of a particular version (or newer)
+#
+#   If no path to the installed boost library is given the macro searchs
+#   under /usr, /usr/local, /opt and /opt/local and evaluates the
+#   $BOOST_ROOT environment variable. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_CPPFLAGS) / AC_SUBST(BOOST_LDFLAGS)
+#
+#   And sets:
+#
+#     HAVE_BOOST
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Peter Adolphs
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 26
+
+AC_DEFUN([AX_BOOST_BASE],
+[
+AC_ARG_WITH([boost],
+  [AS_HELP_STRING([--with-boost@<:@=ARG@:>@],
+    [use Boost library from a standard location (ARG=yes),
+     from the specified location (ARG=<path>),
+     or disable it (ARG=no)
+     @<:@ARG=yes@:>@ ])],
+    [
+    if test "$withval" = "no"; then
+        want_boost="no"
+    elif test "$withval" = "yes"; then
+        want_boost="yes"
+        ac_boost_path=""
+    else
+        want_boost="yes"
+        ac_boost_path="$withval"
+    fi
+    ],
+    [want_boost="yes"])
+
+
+AC_ARG_WITH([boost-libdir],
+        AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
+        [Force given directory for boost libraries. Note that this will override library path detection, so use this parameter only if default library detection fails and you know exactly where your boost libraries are located.]),
+        [
+        if test -d "$withval"
+        then
+                ac_boost_lib_path="$withval"
+        else
+                AC_MSG_ERROR(--with-boost-libdir expected directory name)
+        fi
+        ],
+        [ac_boost_lib_path=""]
+)
+
+if test "x$want_boost" = "xyes"; then
+    boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
+    boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
+    boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
+    boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
+    boost_lib_version_req_sub_minor=`expr $boost_lib_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+    if test "x$boost_lib_version_req_sub_minor" = "x" ; then
+        boost_lib_version_req_sub_minor="0"
+        fi
+    WANT_BOOST_VERSION=`expr $boost_lib_version_req_major \* 100000 \+  $boost_lib_version_req_minor \* 100 \+ $boost_lib_version_req_sub_minor`
+    AC_MSG_CHECKING(for boostlib >= $boost_lib_version_req ($WANT_BOOST_VERSION))
+    succeeded=no
+
+    dnl On 64-bit systems check for system libraries in both lib64 and lib.
+    dnl The former is specified by FHS, but e.g. Debian does not adhere to
+    dnl this (as it rises problems for generic multi-arch support).
+    dnl The last entry in the list is chosen by default when no libraries
+    dnl are found, e.g. when only header-only libraries are installed!
+    libsubdirs="lib"
+    ax_arch=`uname -m`
+    case $ax_arch in
+      x86_64)
+        libsubdirs="lib64 libx32 lib lib64"
+        ;;
+      ppc64|s390x|sparc64|aarch64|ppc64le)
+        libsubdirs="lib64 lib lib64 ppc64le"
+        ;;
+    esac
+
+    dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
+    dnl them priority over the other paths since, if libs are found there, they
+    dnl are almost assuredly the ones desired.
+    AC_REQUIRE([AC_CANONICAL_HOST])
+    libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
+
+    case ${host_cpu} in
+      i?86)
+        libsubdirs="lib/i386-${host_os} $libsubdirs"
+        ;;
+    esac
+
+    dnl first we check the system location for boost libraries
+    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl or if you install boost with RPM
+    if test "$ac_boost_path" != ""; then
+        BOOST_CPPFLAGS="-I$ac_boost_path/include"
+        for ac_boost_path_tmp in $libsubdirs; do
+                if test -d "$ac_boost_path"/"$ac_boost_path_tmp" ; then
+                        BOOST_LDFLAGS="-L$ac_boost_path/$ac_boost_path_tmp"
+                        break
+                fi
+        done
+    elif test "$cross_compiling" != yes; then
+        for ac_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost"; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$ac_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                BOOST_LDFLAGS="-L$ac_boost_path_tmp/$libsubdir"
+                BOOST_CPPFLAGS="-I$ac_boost_path_tmp/include"
+                break;
+            fi
+        done
+    fi
+
+    dnl overwrite ld flags if we have required special directory with
+    dnl --with-boost-libdir parameter
+    if test "$ac_boost_lib_path" != ""; then
+       BOOST_LDFLAGS="-L$ac_boost_lib_path"
+    fi
+
+    CPPFLAGS_SAVED="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+    export CPPFLAGS
+
+    LDFLAGS_SAVED="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+    export LDFLAGS
+
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH(C++)
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <boost/version.hpp>
+    ]], [[
+    #if BOOST_VERSION >= $WANT_BOOST_VERSION
+    // Everything is okay
+    #else
+    #  error Boost version is too old
+    #endif
+    ]])],[
+        AC_MSG_RESULT(yes)
+    succeeded=yes
+    found_system=yes
+        ],[
+        ])
+    AC_LANG_POP([C++])
+
+
+
+    dnl if we found no boost with system layout we search for boost libraries
+    dnl built and installed without the --layout=system option or for a staged(not installed) version
+    if test "x$succeeded" != "xyes"; then
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+        BOOST_CPPFLAGS=
+        BOOST_LDFLAGS=
+        _version=0
+        if test "$ac_boost_path" != ""; then
+            if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
+                    _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                    V_CHECK=`expr $_version_tmp \> $_version`
+                    if test "$V_CHECK" = "1" ; then
+                        _version=$_version_tmp
+                    fi
+                    VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                    BOOST_CPPFLAGS="-I$ac_boost_path/include/boost-$VERSION_UNDERSCORE"
+                done
+                dnl if nothing found search for layout used in Windows distributions
+                if test -z "$BOOST_CPPFLAGS"; then
+                    if test -d "$ac_boost_path/boost" && test -r "$ac_boost_path/boost"; then
+                        BOOST_CPPFLAGS="-I$ac_boost_path"
+                    fi
+                fi
+            fi
+        else
+            if test "$cross_compiling" != yes; then
+                for ac_boost_path in /usr /usr/local /opt /opt/local ; do
+                    if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                        for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
+                            _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                            V_CHECK=`expr $_version_tmp \> $_version`
+                            if test "$V_CHECK" = "1" ; then
+                                _version=$_version_tmp
+                                best_path=$ac_boost_path
+                            fi
+                        done
+                    fi
+                done
+
+                VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
+                if test "$ac_boost_lib_path" = ""; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$best_path/$libsubdir"
+                fi
+            fi
+
+            if test "x$BOOST_ROOT" != "x"; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                if test -d "$BOOST_ROOT" && test -r "$BOOST_ROOT" && test -d "$BOOST_ROOT/stage/$libsubdir" && test -r "$BOOST_ROOT/stage/$libsubdir"; then
+                    version_dir=`expr //$BOOST_ROOT : '.*/\(.*\)'`
+                    stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
+                        stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
+                    V_CHECK=`expr $stage_version_shorten \>\= $_version`
+                    if test "$V_CHECK" = "1" -a "$ac_boost_lib_path" = "" ; then
+                        AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
+                        BOOST_CPPFLAGS="-I$BOOST_ROOT"
+                        BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
+                    fi
+                fi
+            fi
+        fi
+
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
+
+        AC_LANG_PUSH(C++)
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        @%:@include <boost/version.hpp>
+        ]], [[
+        #if BOOST_VERSION >= $WANT_BOOST_VERSION
+        // Everything is okay
+        #else
+        #  error Boost version is too old
+        #endif
+        ]])],[
+            AC_MSG_RESULT(yes)
+        succeeded=yes
+        found_system=yes
+            ],[
+            ])
+        AC_LANG_POP([C++])
+    fi
+
+    if test "$succeeded" != "yes" ; then
+        if test "$_version" = "0" ; then
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $boost_lib_version_req_shorten or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+        else
+            AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
+        fi
+        # execute ACTION-IF-NOT-FOUND (if present):
+        ifelse([$3], , :, [$3])
+    else
+        AC_SUBST(BOOST_CPPFLAGS)
+        AC_SUBST(BOOST_LDFLAGS)
+        AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
+        # execute ACTION-IF-FOUND (if present):
+        ifelse([$2], , :, [$2])
+    fi
+
+    CPPFLAGS="$CPPFLAGS_SAVED"
+    LDFLAGS="$LDFLAGS_SAVED"
+fi
+
+])


### PR DESCRIPTION
This PR Fixes DICL/EclipseMETA#68

Checklist
- [x] Follows Google Coding Style. [Doesn't apply here]
- [x] At least one reviewer approved (for non-trivial changes).

---
 - Configure guess boost lib location
 - Fixed small warnings running sh autogen.sh
 - Automatic version generation when usinh sh configure.ac
 - Updated README
 - Check for sqlite3 in the configure script 