### PR TITLE
--enable-boost-static option for the configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,3 @@
-ACLOCAL_AMFLAGS  = -I m4
 include tests/Makefile.am
 
 AM_CPPFLAGS      = -I@srcdir@/src/common -I@srcdir@/src -include ./config.h $(BOOST_CPPFLAGS)
@@ -39,8 +38,13 @@ libecfs_la_SOURCES  = src/common/hash.cc src/common/settings.cc \
 libecfs_la_LDFLAGS  = $(BOOST_LDFLAGS) -version-info 0:0:0 
 
 # Binaries ----
+if BOOST_STATIC
+AM_LDFLAGS          = -static $(BOOST_LDFLAGS) -Wl,--start-group -Wl,-Bstatic,-lboost_system,-lboost_serialization,-lboost_coroutine,-lboost_thread,-lboost_context,-Bdynamic
+LDADD               = libecfs.la -lrt
+else 
 AM_LDFLAGS          = -static $(BOOST_LDFLAGS)
 LDADD               = libecfs.la -lboost_system -lboost_serialization -lboost_coroutine -lboost_thread -lboost_context
+endif
 
 eclipse_node_SOURCES = src/targets/node_main.cc \
 											 src/network/channel.cc \

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@ AC_ARG_ENABLE([debug],
     [debug="$withval"], [debug=no])
 
 AM_CONDITIONAL(COPY_SAMPLES, [test "$enable_samples" != no ])
+AX_BOOST_STATIC_LINKAGE
 
 #}}}
 # Dependencies checkings {{{
@@ -80,9 +81,10 @@ WARN([\
  Dependencies
  ------------
  [Required]
- Have Boost?......: ${HAVE_BOOST-YES}
- BOOST CPPFLAGS...: $BOOST_CPPFLAGS
- BOOST LDFLAGS....: $BOOST_LDFLAGS
+ Have Boost?.............: ${HAVE_BOOST-YES}
+ BOOST CPPFLAGS..........: $BOOST_CPPFLAGS
+ BOOST LDFLAGS...........: $BOOST_LDFLAGS
+ Static Boost linkage?...: ${enable_boost_static:-NO}
 
  [Optional]
  Have UnitTest++?.: $have_unittest

--- a/m4/AX_BOOST_STATIC_LINKAGE.m4
+++ b/m4/AX_BOOST_STATIC_LINKAGE.m4
@@ -1,0 +1,11 @@
+dnl This function will enable static linkage of the boost library in eclipse.
+dnl This feature aim to ease the cumbersome task of installing boost library
+dnl in a large cluster
+AC_DEFUN([AX_BOOST_STATIC_LINKAGE], 
+[
+
+AC_ARG_ENABLE([boost_static],
+  [AS_HELP_STRING([--enable-boost-static], [statically link boost])])
+
+AM_CONDITIONAL(BOOST_STATIC, [test x$enable_boost_static = xyes])
+])


### PR DESCRIPTION
This PR Fixes DICL/EclipseMETA#70

Checklist
- [x] Follows Google Coding Style.
- [x] At least one reviewer approved (for non-trivial changes).

---
Now configure script has the option:

     --enable-boost-static 

which will link the boost libraries against EclipseDFS statically.

RATIONALE
---

Using this option you will not have to install boost libraries in each node of a cluster, just in the node in which you will compile EclipseDFS